### PR TITLE
fix: canonicalize workflow worker temporary directory

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1,5 +1,5 @@
 import { fork, spawn, type ChildProcess } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
@@ -386,7 +386,7 @@ function workflowErrorFromWorker(error: WorkerErrorShape): WorkflowError {
 export function runWorkflow(script: string, args: JsonValue = null, bridge: WorkflowBridge = {}, signal?: AbortSignal): WorkflowExecution {
   encoded(args);
   const config = JSON.stringify({ script: instrumentWorkflow(script), args: structuredClone(args), functions: bridge.functions ?? {}, variables: bridge.variables ?? {} });
-  const childDir = mkdtempSync(join(tmpdir(), "pi-wf-"));
+  const childDir = realpathSync(mkdtempSync(join(tmpdir(), "pi-wf-")));
   const childFile = join(childDir, "child.cjs");
   writeFileSync(childFile, childSource);
   const child: ChildProcess = fork(childFile, [String(RPC_LIMIT_BYTES), config], {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { join, resolve } from "node:path";
@@ -3250,6 +3250,27 @@ void test("permission-sandboxed child cannot read files, reach network, or spawn
   const hostile = runWorkflow(`export const meta={name:'hostile',description:'hostile'}; try { const fs = globalThis.constructor.constructor('return require("node:fs")')(); return fs.readFileSync('/etc/hostname','utf8'); } catch(e) { return 'blocked:'+e.code; }`);
   const result = await hostile.result as string;
   assert.match(result, /blocked:/);
+});
+
+void test("workflow workers support a symlinked temporary directory", async () => {
+  const tmpdirVariable = process.platform === "win32" ? "TEMP" : "TMPDIR";
+  const originalTmpdir = process.env[tmpdirVariable];
+  const root = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-symlinked-tmp-"));
+  const realTmpdir = join(root, "real");
+  const symlinkedTmpdir = join(root, "link");
+  mkdirSync(realTmpdir);
+  symlinkSync(realTmpdir, symlinkedTmpdir, process.platform === "win32" ? "junction" : "dir");
+  process.env[tmpdirVariable] = symlinkedTmpdir;
+
+  try {
+    assert.equal(await runWorkflow("return 42;").result, 42);
+  } finally {
+    if (originalTmpdir === undefined) {
+      if (tmpdirVariable === "TEMP") delete process.env.TEMP;
+      else delete process.env.TMPDIR;
+    } else process.env[tmpdirVariable] = originalTmpdir;
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 void test("workflow cancellation reaches an active top-level scheduler agent", async () => {


### PR DESCRIPTION
## Summary

- canonicalize the workflow worker's temporary directory before constructing the child entry-point path and Node permission allowlist
- add a regression test covering symlinked temporary directories
- use a directory junction and `TEMP` on Windows so the regression test remains portable

## Why

On macOS, the default temporary directory can be exposed as `/var/folders/...` while its canonical path is `/private/var/folders/...`. With Node.js 26's permission model, granting `--allow-fs-read` only for the non-canonical path causes the worker to exit with `ERR_ACCESS_DENIED` before it can send an IPC message.

Resolving the newly created worker directory with `realpathSync()` ensures that both the worker entry point and `--allow-fs-read` use the same canonical path. Cleanup continues to use that same directory.

## Testing

- `npm run lint`
- `npm run build`
- `TMPDIR=/private/tmp node --test --test-name-pattern='permission-sandboxed child|workflow workers support a symlinked temporary directory' dist/test/index.test.js`
- direct `runWorkflow("return 42;")` reproduction on macOS with Node.js 26.3.0
- `npm run docs:check`

Closes #121
