### PR TITLE
fix: tolerate host sleep in worker watchdog

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -13,6 +13,7 @@ import { instrumentWorkflow, validateAgentOptions, validateShellCommand, validat
 export const RPC_LIMIT_BYTES = 10 * 1024 * 1024;
 type WorkerErrorShape = { code?: string; message: string; authored?: boolean; failedAt?: string };
 export const HEARTBEAT_TIMEOUT_MS = 5000;
+const HEARTBEAT_INTERVAL_MS = 1000;
 
 const OUTCOME_ERRORS = new Set<string>(["AGENT_TIMEOUT", "AGENT_FAILED", "RESULT_INVALID"]);
 const WORK_RESULT_BRAND = "__workResult";
@@ -64,7 +65,7 @@ process.on("message", raw => {
   if (message.ok) request.resolve(message.value);
   else request.reject(workflowError(message.error));
 });
-const heartbeat = setInterval(() => send({ type: "heartbeat" }), 1000);
+const heartbeat = setInterval(() => send({ type: "heartbeat" }), ${HEARTBEAT_INTERVAL_MS});
 send({ type: "heartbeat" });
 const BRAND = "${WORK_RESULT_BRAND}";
 const workError = (code, message) => Object.assign(new Error(message), { code });
@@ -416,7 +417,16 @@ export function runWorkflow(script: string, args: JsonValue = null, bridge: Work
   const controller = new AbortController();
   let settled = false;
   let rejectResult: (error: WorkflowError) => void = () => undefined;
-  let watchdog = setTimeout(() => { stop("WORKER_UNRESPONSIVE", "Workflow worker missed its five-second heartbeat"); }, HEARTBEAT_TIMEOUT_MS);
+  let lastHeartbeatAt = performance.now();
+  let lastWatchdogCheckAt = lastHeartbeatAt;
+  const watchdog = setInterval(() => {
+    const now = performance.now();
+    // A check delayed enough to bridge the normal heartbeat margin makes elapsed time unreliable.
+    const watchdogCheckWasDelayed = now - lastWatchdogCheckAt >= HEARTBEAT_TIMEOUT_MS - HEARTBEAT_INTERVAL_MS;
+    lastWatchdogCheckAt = now;
+    if (watchdogCheckWasDelayed) { lastHeartbeatAt = now; return; }
+    if (now - lastHeartbeatAt >= HEARTBEAT_TIMEOUT_MS) stop("WORKER_UNRESPONSIVE", "Workflow worker missed its five-second heartbeat");
+  }, HEARTBEAT_INTERVAL_MS);
   const result = new Promise<JsonValue>((resolve, reject) => {
     rejectResult = reject;
     child.on("message", (raw: unknown) => {
@@ -424,7 +434,7 @@ export function runWorkflow(script: string, args: JsonValue = null, bridge: Work
         if (typeof raw !== "string" || Buffer.byteLength(raw) > RPC_LIMIT_BYTES) fail("RPC_LIMIT_EXCEEDED", "RPC value exceeds the 10 MB JSON boundary");
         const message = JSON.parse(raw) as { type?: string; id?: number; method?: string; args?: JsonValue[]; ok?: boolean; value?: JsonValue; error?: WorkerErrorShape };
         if (!jsonValue(message)) fail("RPC_LIMIT_EXCEEDED", "Worker RPC must contain JSON-compatible values");
-        if (message.type === "heartbeat") { clearTimeout(watchdog); watchdog = setTimeout(() => { stop("WORKER_UNRESPONSIVE", "Workflow worker missed its five-second heartbeat"); }, HEARTBEAT_TIMEOUT_MS); return; }
+        if (message.type === "heartbeat") { lastHeartbeatAt = performance.now(); return; }
         if (message.type === "result") { encoded(message.value); finish(); resolve(message.value ?? null); return; }
         if (message.type === "error") { finish(); reject(workflowErrorFromWorker(message.error ?? { code: "INTERNAL_ERROR", message: "Worker failed" })); return; }
         if (message.type === "rpc" && message.id !== undefined) void handleRpc(message.id, message.method ?? "", message.args ?? []);
@@ -439,7 +449,7 @@ export function runWorkflow(script: string, args: JsonValue = null, bridge: Work
       setTimeout(() => { if (!child.killed) child.kill("SIGKILL"); }, 1000).unref();
     }
   }
-  function finish() { settled = true; clearTimeout(watchdog); signal?.removeEventListener("abort", cancel); killChild(); rmSync(childDir, { recursive: true, force: true }); }
+  function finish() { settled = true; clearInterval(watchdog); signal?.removeEventListener("abort", cancel); killChild(); rmSync(childDir, { recursive: true, force: true }); }
   function stop(code: WorkflowErrorCode, message: string) { if (settled) return; controller.abort(); finish(); rejectResult(new WorkflowError(code, message)); }
   function branded(result: Record<string, JsonValue>): JsonValue { return { ...result, [WORK_RESULT_BRAND]: true }; }
   async function handleRpc(id: number, method: string, values: JsonValue[]) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3693,6 +3693,20 @@ void test("worker watchdog terminates a synchronous heartbeat stall after five s
   const elapsed = performance.now() - started;
   assert.ok(elapsed >= 4900 && elapsed < 6500, `watchdog fired after ${String(elapsed)}ms`);
 });
+void test("worker watchdog tolerates a delayed parent event loop while agent work is pending", { timeout: 8000 }, async () => {
+  let started!: () => void;
+  let release!: () => void;
+  let agentCalls = 0;
+  const agentStarted = new Promise<void>((resolve) => { started = resolve; });
+  const agentResult = new Promise<string>((resolve) => { release = () => { resolve("done"); }; });
+  const run = runWorkflow(`return await agent("wait");`, null, { agent: async () => { agentCalls += 1; started(); return agentResult; } });
+  await agentStarted;
+  execFileSync(process.execPath, ["-e", "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5500)"]);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  release();
+  assert.equal(await run.result, "done");
+  assert.equal(agentCalls, 1);
+});
 
 void test("worker enforces 10 MB boundaries on individual and final JSON values", async () => {
   const oversized = "x".repeat(RPC_LIMIT_BYTES);


### PR DESCRIPTION
## Summary

- replace the resettable one-shot worker watchdog with periodic parent-side checks
- detect when the parent watchdog cadence was delayed enough to make heartbeat elapsed time unreliable and grant the worker a fresh timeout window
- retain `WORKER_UNRESPONSIVE` detection when the parent remains responsive but worker heartbeats stop
- add regression coverage for a delayed parent event loop while agent work is pending

## Why

During macOS sleep, both the parent process and workflow worker stop making event-loop progress. On wake, the parent's overdue watchdog can run before the healthy worker's queued or next heartbeat is processed, incorrectly terminating the workflow.

The new watchdog tracks both the last heartbeat and the last parent watchdog check. A parent-check delay of at least the normal heartbeat margin (`HEARTBEAT_TIMEOUT_MS - HEARTBEAT_INTERVAL_MS`) grants a fresh heartbeat window. Normal watchdog cadence still terminates a worker-only stall after five seconds.

## Testing

- `npm run build`
- focused watchdog tests, including verification that the regression test fails on current `upstream/main` and passes with this change
- `npm run lint`
- `npm run docs:check`
- manual macOS sleep/wake workflow testing

Closes #146
