### PR TITLE
fix: retry EPERM on atomicWriteFile rename (Windows)

### DIFF
--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -195,17 +195,36 @@ export function atomicWriteFile(path: string, content: string, sync = false): Pr
   if (sync) {
     try {
       writeFileSync(temporary, content, { encoding: "utf8", mode: 0o600 });
-      renameSync(temporary, path);
+      retryRenameSync(temporary, path);
     } catch (error) {
       try { rmSync(temporary, { force: true }); } catch { /* Preserve the original write error. */ }
       throw error;
     }
     return;
   }
-  return writeFile(temporary, content, { encoding: "utf8", mode: 0o600 }).then(() => rename(temporary, path)).catch(async (error: unknown) => {
+  return writeFile(temporary, content, { encoding: "utf8", mode: 0o600 }).then(() => retryRename(temporary, path)).catch(async (error: unknown) => {
     try { await rm(temporary, { force: true }); } catch { /* Preserve the original write error. */ }
     throw error;
   });
+}
+
+function retryRenameSync(temporary: string, path: string): void {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try { renameSync(temporary, path); return; }
+    catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EPERM" || attempt === 2) throw err;
+    }
+  }
+}
+
+async function retryRename(temporary: string, path: string): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try { await rename(temporary, path); return; }
+    catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EPERM" || attempt === 2) throw err;
+      await new Promise(r => setTimeout(r, 50));
+    }
+  }
 }
 
 async function atomicJson(path: string, value: unknown): Promise<void> {


### PR DESCRIPTION
## Problem

`atomicWriteFile` in `src/persistence.ts` uses a write-to-tmp-then-rename pattern. On Windows, antivirus, search indexers, or backup agents briefly open `.tmp` files between `writeFile` and `rename`, causing `rename` to fail with `EPERM`. This crashes pi because the error propagates uncaught through the workflow state/journal persistence layer.

Reproduced reliably on Windows 11 with a multi-agent workflow (~19 agents writing state files concurrently). Without the fix, `EPERM` occurs within seconds of starting a run.

## Fix

Wrap both `renameSync` (sync path) and `rename` (async path) with retry loops: 3 attempts, only retrying on `EPERM`. Async path adds 50ms backoff between retries.

- Added `retryRenameSync()` — sync retry helper, 0ms delay
- Added `retryRename()` — async retry helper, 50ms backoff
- Updated `atomicWriteFile` to delegate rename calls to these helpers

## Platform impact

**Zero effect on Unix/Linux/macOS.** `rename` on Unix is atomic at the filesystem level — open file handles don't block it, and `EPERM` never fires on tmp file renames. The retry loop's first attempt always succeeds.

On Windows, the retry fires only when `EPERM` is hit (AV/indexer opened the tmp file in the sub-millisecond write→rename gap). In a ~45-write run, typically 0-2 writes need a retry.

## Testing

Verified on Windows 11 across multiple workflow runs (~19 agents each). Zero EPERM crashes after the fix.