### PR TITLE
fix: allow symlinked launch cwd worktrees

### DIFF
--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { renameSync, rmSync, writeFileSync } from "node:fs";
-import { access, link, mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { access, link, mkdir, open, readFile, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 import { promisify } from "node:util";
@@ -705,7 +705,7 @@ export class RunStore {
       let worktreeCreated = false;
       try {
         const root = (await git(this.cwd, ["rev-parse", "--show-toplevel"])).trim();
-        const launchRelative = relative(root, this.cwd);
+        const launchRelative = relative(await realpath(root), await realpath(this.cwd));
         if (launchRelative.startsWith("..")) throw new Error("launch cwd is outside the repository");
         await this.cleanupMarker(markerPath);
         await mkdir(dirname(path), { recursive: true, mode: 0o700 });

--- a/packages/core/test/persistence.test.ts
+++ b/packages/core/test/persistence.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -292,6 +292,27 @@ void test("creates deterministic snapshot worktrees, preserves launch subdirecto
   await store.delete(true);
   assert.equal(existsSync(first.path), false);
   assert.throws(() => execFileSync("git", ["-C", repo, "rev-parse", "--verify", first.branch], { stdio: "ignore" }));
+});
+
+void test("creates worktrees from symlinked launch cwd and preserves its spelling", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-worktree-alias-"));
+  const repo = join(home, "repo");
+  const repoCwd = join(repo, "packages", "app");
+  const alias = join(home, "repo-alias");
+  const launchCwd = join(alias, "packages", "app");
+  mkdirSync(repoCwd, { recursive: true });
+  execFileSync("git", ["init", "-q", repo]);
+  execFileSync("git", ["-C", repo, "config", "user.name", "test"]);
+  execFileSync("git", ["-C", repo, "config", "user.email", "test@example.com"]);
+  writeFileSync(join(repoCwd, "tracked.txt"), "initial");
+  execFileSync("git", ["-C", repo, "add", "."]);
+  execFileSync("git", ["-C", repo, "commit", "-qm", "initial"]);
+  symlinkSync(repo, alias, process.platform === "win32" ? "junction" : "dir");
+  const store = new RunStore(launchCwd, "session-a", "run-a", home);
+  await store.create(run(launchCwd), snapshot);
+  const worktree = await store.worktree("agent");
+  assert.equal((await store.load()).run.cwd, launchCwd);
+  assert.equal(worktree.cwd, join(worktree.path, "packages", "app"));
 });
 void test("does not advertise non-canonical named worktree owners", async () => {
   const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-non-canonical-named-worktree-"));


### PR DESCRIPTION
## Summary

- Cause: worktree containment compared Git’s canonical repository root with a symlink-alias launch cwd lexically, rejecting valid macOS paths.
- Fix: realpath-normalize only the repository root and launch cwd for containment, while preserving the original `run.cwd` spelling.
- Add a regression test for symlinked launch directories.

## Testing

- `npm run build --workspace=packages/core`
- `node --test packages/core/dist/test/persistence.test.js` (31/31)
- `npm run lint --workspace=packages/core`
- `git diff --check`

Closes #161