### PR TITLE
feat: Advanced orchestration patterns (CLI Wrapper & Dynamic Model Router)

### DIFF
--- a/examples/advanced-patterns/auto-model-router.mjs
+++ b/examples/advanced-patterns/auto-model-router.mjs
@@ -1,70 +1,80 @@
 /**
- * Auto-Model Router for pi-extensible-workflows
- * 
- * Automatically detects available AI models and quotas (e.g., via Cockpit Tools or similar external quota managers)
- * and dynamically updates `settings.json` with the best available model for each role (developer, reviewer, scout, etc.).
- * 
- * This ensures deterministic workflows never fail due to hardcoded, out-of-quota, or deprecated models.
+ * Dynamic Model Router (extension pattern)
+ *
+ * Instead of mutating `settings.json` on disk, this registers trusted dynamic
+ * `modelAliases`. Each alias exposes a `resolve(context)` that runs once per
+ * launch (before preflight/availability checks) and picks the best model from
+ * the live `context.availableModels` inventory.
+ *
+ * This keeps deterministic workflows from failing on hardcoded, out-of-quota,
+ * or deprecated models, while staying inside the documented extension API:
+ * https://vekexasia.github.io/pi-extensible-workflows/extensions.html#model-aliases
+ *
+ * Static aliases in global/project settings still override these package
+ * defaults, so operators keep the final say.
+ *
+ * Load it from a Pi extension location, e.g. `~/.pi/agent/extensions/`.
  */
 
-import fs from 'fs';
-import { execSync } from 'child_process';
-import path from 'path';
-import os from 'os';
+import { registerWorkflowExtension } from 'pi-extensible-workflows';
 
-// Path to your external quota/auth manager script (e.g., Cockpit Tools)
-const COCKPIT_CLI = process.env.COCKPIT_CLI_PATH || path.join(os.homedir(), '.cockpit/scripts/cockpit-reader.mjs');
-const SETTINGS_PATH = process.env.PI_WORKFLOWS_SETTINGS || path.join(os.homedir(), '.pi/agent/pi-extensible-workflows/settings.json');
+// Optional provider/proxy prefix for bare model IDs. `availableModels` already
+// carries `provider/model` targets, so only apply this to bare names.
+const PROVIDER = process.env.PI_ROUTER_PROVIDER || '';
 
-try {
-  // 1. Fetch live quotas and available models
-  const out = execSync(`node "${COCKPIT_CLI}" status`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
-  const data = JSON.parse(out);
+const withProvider = (name) =>
+  !PROVIDER || name.includes('/') ? name : `${PROVIDER}/${name}`;
 
-  // 2. Filter available models with > 0% quota
-  const availableModels = data.models
-    .filter(m => m.percentage > 0)
-    .map(m => m.name);
+// Split the live inventory into capability tiers by well-known name markers.
+function classify(availableModels) {
+  const models = [...availableModels];
 
-  if (availableModels.length === 0) {
-    console.error("No available models with quota.");
-    process.exit(1);
-  }
+  const tier1 = models.filter((m) =>
+    /(pro|agent|sonnet|opus)/i.test(m)
+  );
+  const tier2 = models.filter(
+    (m) => /flash/i.test(m) && !/(lite|low|extra)/i.test(m)
+  );
+  const tier3 = models.filter((m) => /(lite|low|haiku)/i.test(m));
 
-  // 3. Categorize by capabilities/effort (Example for Gemini/Claude)
-  const tier1 = availableModels.filter(m => m.includes('pro') || m.includes('agent') || m.includes('sonnet') || m.includes('opus'));
-  const tier2 = availableModels.filter(m => m.includes('flash') && !m.includes('lite') && !m.includes('low') && !m.includes('extra'));
-  const tier3 = availableModels.filter(m => m.includes('lite') || m.includes('low') || m.includes('haiku'));
-
-  const bestCode = tier1[0] || tier2[0] || availableModels[0];
-  const bestReview = tier1.find(m => m.includes('agent') || m.includes('opus')) || bestCode;
+  const bestCode = tier1[0] || tier2[0] || models[0];
+  const bestReview =
+    tier1.find((m) => /(agent|opus)/i.test(m)) || bestCode;
   const bestMid = tier2[0] || bestCode;
-  const bestFast = tier3[0] || tier2[0] || availableModels[0];
+  const bestFast = tier3[0] || tier2[0] || models[0];
 
-  // 4. Update the pi-extensible-workflows settings.json
-  const settings = fs.existsSync(SETTINGS_PATH) ? JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8')) : { modelAliases: {} };
-  
-  // Use 'antigravity' or your preferred proxy provider prefix
-  const provider = "antigravity"; 
+  return { bestCode, bestReview, bestMid, bestFast };
+}
 
-  settings.modelAliases = {
-    ...settings.modelAliases,
-    "reviewer-model": `${provider}/${bestReview}`,
-    "scout-model": `${provider}/${bestFast}`,
-    "cheap-model": `${provider}/${bestFast}`,
-    "developer-model": `${provider}/${bestCode}`,
-    "fast": `${provider}/${bestFast}`,
-    "smart": `${provider}/${bestCode}`,
-    "deep": `${provider}/${bestReview}`,
-    "planner-model": `${provider}/${bestCode}`,
-    "security-model": `${provider}/${bestReview}`,
-    "designer-model": `${provider}/${bestMid}`
-  };
+// Build a resolver that picks a target from the live inventory. Returning a
+// non-available or invalid target fails the launch before any run starts, so
+// throw a clear error when nothing matches.
+const pick = (select) => ({
+  async resolve({ availableModels }) {
+    if (availableModels.size === 0) {
+      throw new Error('auto-model-router: no available models');
+    }
+    return withProvider(select(classify(availableModels)));
+  },
+});
 
-  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
-  console.log("pi-extensible-workflows successfully routed to active models:");
-  console.log(JSON.stringify(settings.modelAliases, null, 2));
-
-} catch (err) {
-  console.error("Failed to dynamically route models:", err.message);
+export default function extension() {
+  registerWorkflowExtension({
+    version: '1.0.0',
+    headline: 'Dynamic model router',
+    description:
+      'Resolves role/tier aliases to the best available model at launch.',
+    modelAliases: {
+      'developer-model': pick((t) => t.bestCode),
+      'reviewer-model': pick((t) => t.bestReview),
+      'scout-model': pick((t) => t.bestFast),
+      'cheap-model': pick((t) => t.bestFast),
+      'planner-model': pick((t) => t.bestCode),
+      'security-model': pick((t) => t.bestReview),
+      'designer-model': pick((t) => t.bestMid),
+      fast: pick((t) => t.bestFast),
+      smart: pick((t) => t.bestCode),
+      deep: pick((t) => t.bestReview),
+    },
+  });
 }

--- a/examples/advanced-patterns/auto-model-router.mjs
+++ b/examples/advanced-patterns/auto-model-router.mjs
@@ -1,0 +1,70 @@
+/**
+ * Auto-Model Router for pi-extensible-workflows
+ * 
+ * Automatically detects available AI models and quotas (e.g., via Cockpit Tools or similar external quota managers)
+ * and dynamically updates `settings.json` with the best available model for each role (developer, reviewer, scout, etc.).
+ * 
+ * This ensures deterministic workflows never fail due to hardcoded, out-of-quota, or deprecated models.
+ */
+
+import fs from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+import os from 'os';
+
+// Path to your external quota/auth manager script (e.g., Cockpit Tools)
+const COCKPIT_CLI = process.env.COCKPIT_CLI_PATH || path.join(os.homedir(), '.cockpit/scripts/cockpit-reader.mjs');
+const SETTINGS_PATH = process.env.PI_WORKFLOWS_SETTINGS || path.join(os.homedir(), '.pi/agent/pi-extensible-workflows/settings.json');
+
+try {
+  // 1. Fetch live quotas and available models
+  const out = execSync(`node "${COCKPIT_CLI}" status`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
+  const data = JSON.parse(out);
+
+  // 2. Filter available models with > 0% quota
+  const availableModels = data.models
+    .filter(m => m.percentage > 0)
+    .map(m => m.name);
+
+  if (availableModels.length === 0) {
+    console.error("No available models with quota.");
+    process.exit(1);
+  }
+
+  // 3. Categorize by capabilities/effort (Example for Gemini/Claude)
+  const tier1 = availableModels.filter(m => m.includes('pro') || m.includes('agent') || m.includes('sonnet') || m.includes('opus'));
+  const tier2 = availableModels.filter(m => m.includes('flash') && !m.includes('lite') && !m.includes('low') && !m.includes('extra'));
+  const tier3 = availableModels.filter(m => m.includes('lite') || m.includes('low') || m.includes('haiku'));
+
+  const bestCode = tier1[0] || tier2[0] || availableModels[0];
+  const bestReview = tier1.find(m => m.includes('agent') || m.includes('opus')) || bestCode;
+  const bestMid = tier2[0] || bestCode;
+  const bestFast = tier3[0] || tier2[0] || availableModels[0];
+
+  // 4. Update the pi-extensible-workflows settings.json
+  const settings = fs.existsSync(SETTINGS_PATH) ? JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8')) : { modelAliases: {} };
+  
+  // Use 'antigravity' or your preferred proxy provider prefix
+  const provider = "antigravity"; 
+
+  settings.modelAliases = {
+    ...settings.modelAliases,
+    "reviewer-model": `${provider}/${bestReview}`,
+    "scout-model": `${provider}/${bestFast}`,
+    "cheap-model": `${provider}/${bestFast}`,
+    "developer-model": `${provider}/${bestCode}`,
+    "fast": `${provider}/${bestFast}`,
+    "smart": `${provider}/${bestCode}`,
+    "deep": `${provider}/${bestReview}`,
+    "planner-model": `${provider}/${bestCode}`,
+    "security-model": `${provider}/${bestReview}`,
+    "designer-model": `${provider}/${bestMid}`
+  };
+
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
+  console.log("pi-extensible-workflows successfully routed to active models:");
+  console.log(JSON.stringify(settings.modelAliases, null, 2));
+
+} catch (err) {
+  console.error("Failed to dynamically route models:", err.message);
+}

--- a/examples/advanced-patterns/hostile-cli-wrapper.js
+++ b/examples/advanced-patterns/hostile-cli-wrapper.js
@@ -1,0 +1,40 @@
+/**
+ * Hostile CLI Wrapper Pattern
+ * 
+ * Safely wrap unpredictable CLI tools (that hang, print messy stdout, or exit(0) on failure)
+ * into deterministic, structured JSON for pi-extensible-workflows.
+ */
+const { spawnSync } = require('child_process');
+
+function runHostileCli(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf-8',
+    timeout: options.timeout || 30000, // Hard limit to prevent hanging workflows
+    env: { ...process.env, CI: 'true' } // Disable interactive prompts
+  });
+
+  // 1. Handle actual process execution errors or timeouts
+  if (result.error) {
+    if (result.error.code === 'ETIMEDOUT') return { status: 'error', reason: 'timeout' };
+    return { status: 'error', reason: result.error.message };
+  }
+
+  // 2. Handle deceptive exits (e.g., exit 0 but logged to stderr, or exit != 0 with no stdout)
+  if (result.status !== 0 && !result.stdout) {
+    return { status: 'failed', stderr: result.stderr };
+  }
+
+  // 3. Force output into clean JSON (bypassing deprecation warnings or verbose text)
+  try {
+    const rawOut = (result.stdout || '').trim();
+    // Example: Strip anything before the first '{' if the CLI prints ASCII logos or warnings
+    const jsonStart = rawOut.indexOf('{');
+    const cleanJson = jsonStart >= 0 ? rawOut.substring(jsonStart) : rawOut;
+    
+    return { status: 'success', data: JSON.parse(cleanJson) };
+  } catch (e) {
+    return { status: 'dirty_output', raw: result.stdout };
+  }
+}
+
+module.exports = runHostileCli;

--- a/examples/advanced-patterns/hostile-cli-wrapper.js
+++ b/examples/advanced-patterns/hostile-cli-wrapper.js
@@ -3,11 +3,34 @@
  *
  * "Hostile CLI" is not a formal term: here it means any command-line tool that
  * is unsafe to consume programmatically because it behaves non-deterministically.
+ * It may work fine when a human runs it by hand, yet break an automated workflow
+ * because a subagent cannot trust its stdout or its exit code.
+ *
  * Typical traits:
  *   - hangs or waits on interactive prompts instead of exiting;
  *   - prints logos, deprecation warnings, or progress noise into stdout;
  *   - exits 0 on failure (or non-zero with an empty stdout), so the exit code lies;
  *   - emits human-formatted text where a workflow expects machine-readable JSON.
+ *
+ * Well-known real-world offenders:
+ *   - `apt-get install` hangs on the interactive `tzdata` prompt unless you set
+ *     DEBIAN_FRONTEND=noninteractive (same spirit as CI=true below);
+ *   - `npm install` mixes progress bars, `npm warn deprecated` and funding
+ *     messages into stdout, corrupting any structured read;
+ *   - `npm audit` exits non-zero when it finds vulnerabilities, breaking CI even
+ *     though the install itself succeeded (an exit code that "lies" the other way);
+ *   - `pip install` injects `WARNING: You are using pip version ...` into output;
+ *   - `git clone` / `git push` block waiting for credentials instead of failing;
+ *   - `docker pull` animates progress bars that pollute stdout.
+ *
+ * Cases seen while running massive cross-platform installs in Wizard-AI
+ * (https://github.com/darkrei08/Wizard-AI) via a `wz-ai os install` layer:
+ *   1. Hanging installs - an `apt` waiting on an interactive prompt froze an
+ *      entire batch of tool installs; the subagent stayed alive with no error.
+ *   2. JSON broken by warnings - parsing `pip`/`npm` output as JSON exploded
+ *      because the tool prepended a banner or a deprecation warning.
+ *   3. Lying exit codes - installs "succeeding" with exit 0 while silently
+ *      skipping half the packages; the agent marched on and crashed far away.
  *
  * This wrapper normalizes such tools into deterministic, structured JSON so they
  * can feed the deterministic workflows described in the project docs:

--- a/examples/advanced-patterns/hostile-cli-wrapper.js
+++ b/examples/advanced-patterns/hostile-cli-wrapper.js
@@ -1,8 +1,17 @@
 /**
  * Hostile CLI Wrapper Pattern
- * 
- * Safely wrap unpredictable CLI tools (that hang, print messy stdout, or exit(0) on failure)
- * into deterministic, structured JSON for pi-extensible-workflows.
+ *
+ * "Hostile CLI" is not a formal term: here it means any command-line tool that
+ * is unsafe to consume programmatically because it behaves non-deterministically.
+ * Typical traits:
+ *   - hangs or waits on interactive prompts instead of exiting;
+ *   - prints logos, deprecation warnings, or progress noise into stdout;
+ *   - exits 0 on failure (or non-zero with an empty stdout), so the exit code lies;
+ *   - emits human-formatted text where a workflow expects machine-readable JSON.
+ *
+ * This wrapper normalizes such tools into deterministic, structured JSON so they
+ * can feed the deterministic workflows described in the project docs:
+ * https://vekexasia.github.io/pi-extensible-workflows/
  */
 const { spawnSync } = require('child_process');
 

--- a/examples/advanced-patterns/parallel-wrapper-workflow.js
+++ b/examples/advanced-patterns/parallel-wrapper-workflow.js
@@ -1,0 +1,24 @@
+/**
+ * Using the Hostile CLI Wrapper in a parallel workflow
+ * 
+ * This workflow demonstrates fanning out a wrapper script to parse multiple
+ * modules deterministically, before handing the clean data to the LLM.
+ */
+
+const runHostileCli = require('./hostile-cli-wrapper.js');
+
+module.exports = function() {
+  // Step 1: Execute the wrapper locally (synchronously) to gather clean deterministic data
+  // without wasting LLM context on error logs or CLI formatting.
+  const frontendData = runHostileCli('my-hostile-cli', ['analyze', './src/frontend', '--json']);
+  const backendData = runHostileCli('my-hostile-cli', ['analyze', './src/backend', '--json']);
+
+  // Step 2: Pass the cleanly parsed, safe JSON to parallel subagents
+  const { docFront, docBack } = parallel("document-modules", {
+    docFront: agent(`Document the frontend based on this strict structural data: ${JSON.stringify(frontendData)}`, { role: "developer" }),
+    docBack: agent(`Document the backend based on this strict structural data: ${JSON.stringify(backendData)}`, { role: "developer" })
+  });
+
+  // Step 3: Summarize
+  return agent(`Merge the frontend and backend documentation:\n\nFrontend:\n${docFront}\n\nBackend:\n${docBack}`, { role: "reviewer" });
+};


### PR DESCRIPTION
## Cosa aggiunge questa PR

Due pattern di orchestrazione avanzata, esplorati per l'uso reale nei subagent paralleli, sotto `examples/advanced-patterns/`:

1. **Dynamic Model Router** (`auto-model-router.mjs`) — risoluzione dinamica di quote/modelli tramite `registerWorkflowExtension` con resolver `modelAliases` che leggono `context.availableModels` a runtime, **senza** mutare `settings.json` su disco.
2. **Hostile CLI Wrapper** (`hostile-cli-wrapper.js` + `parallel-wrapper-workflow.js`) — wrapping deterministico di CLI "ostili" per poterle consumare in sicurezza dentro workflow automatici e subagent paralleli.

## Cos'è una "hostile CLI"

Non è un termine formale. Indica qualsiasi tool a riga di comando **insicuro da consumare a livello programmatico** perché si comporta in modo **non deterministico**: a mano funziona benissimo, ma dentro uno script ti frega, perché un subagent non può fidarsi né del suo `stdout` né del suo exit code.

Tratti tipici:
- si blocca su prompt interattivi invece di uscire;
- stampa logo, warning di deprecation o rumore di progress su `stdout`;
- esce con codice `0` in caso di errore (o `!= 0` con `stdout` vuoto): l'exit code mente;
- emette testo umano dove il workflow si aspetta JSON.

### Offender classici (li conosce chiunque scriva automazione)
- **`apt-get install`** — si pianta sul prompt interattivo di `tzdata` finché non imposti `DEBIAN_FRONTEND=noninteractive` (stesso spirito del `CI=true` usato nel wrapper);
- **`npm install`** — mescola progress bar, `npm warn deprecated` e messaggi di funding su `stdout`;
- **`npm audit`** — esce `!= 0` se trova vulnerabilità, rompendo la CI anche quando l'install è riuscito (exit code che "mente" al contrario);
- **`pip install`** — infila `WARNING: You are using pip version ...` in mezzo all'output;
- **`git clone` / `git push`** — si bloccano ad aspettare le credenziali invece di fallire;
- **`docker pull`** — progress bar animate che sporcano lo `stdout`.

### Casi reali dal mio Wizard-AI
Il pattern nasce da un problema concreto su [**Wizard-AI**](https://github.com/darkrei08/Wizard-AI), dove faccio **installazioni massive cross-platform** (Arch, Ubuntu, Fedora, macOS, WSL) tramite un layer `wz-ai os install`. Lì ogni package manager si è rivelato una hostile CLI a modo suo:
1. **Install appesi all'infinito** — un `apt` fermo su un prompt interattivo bloccava l'intero batch; il subagent restava vivo, senza errori.
2. **JSON rotto dai warning** — parsare l'output di `pip`/`npm` come JSON esplodeva perché il tool ci aveva infilato davanti un banner o un warning.
3. **Exit code bugiardi** — install "riusciti" con `exit 0` ma che avevano saltato metà pacchetti; l'agente proseguiva e crashava dopo, lontano dal punto reale del problema.

## Come il wrapper risolve

Normalizza tutto in un contratto deterministico a quattro stati — `success` / `failed` / `timeout` / `dirty_output` — così i subagent paralleli sanno sempre cosa aspettarsi:

```js
const result = spawnSync(command, args, {
  encoding: 'utf-8',
  timeout: options.timeout || 30000,      // install appesi
  env: { ...process.env, CI: 'true' }     // prompt interattivi (come DEBIAN_FRONTEND)
});
if (result.error?.code === 'ETIMEDOUT') return { status: 'error', reason: 'timeout' };
if (result.status !== 0 && !result.stdout) return { status: 'failed', stderr: result.stderr }; // exit code bugiardo
const jsonStart = rawOut.indexOf('{');   // banner/warning davanti al JSON
const cleanJson = jsonStart >= 0 ? rawOut.substring(jsonStart) : rawOut;
return { status: 'success', data: JSON.parse(cleanJson) };
```

Gli stessi esempi e casi reali sono ora anche nel commento header di `hostile-cli-wrapper.js`, così chi apre il file capisce subito cosa si intende.
