### PR TITLE
fix: handle macOS path aliases outside workflow workers

### DIFF
--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -23,7 +23,7 @@ function pi(overrides: Partial<DoctorPiState> = {}): DoctorPiState {
 }
 
 function fixture(): { root: string; cwd: string; agentDir: string; settingsPath: string } {
-  const root = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-doctor-"));
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "pi-extensible-workflows-doctor-")));
   const cwd = join(root, "project");
   const agentDir = join(root, "agent");
   mkdirSync(join(cwd, ".pi", "pi-extensible-workflows", "roles"), { recursive: true });

--- a/packages/core/src/agent-execution.ts
+++ b/packages/core/src/agent-execution.ts
@@ -145,6 +145,12 @@ function accounting(stats: WorkflowAgentSessionStats): AgentAccounting {
   return { input: stats.tokens.input, output: stats.tokens.output, cacheRead: stats.tokens.cacheRead, cacheWrite: stats.tokens.cacheWrite, cost: stats.cost };
 }
 function canonicalSourcePath(path: string): string { try { return realpathSync(path); } catch { return resolve(path); } }
+function canonicalExtensionSelector(selector: string): string {
+  const negated = selector.startsWith("!");
+  const body = negated ? selector.slice(1) : selector;
+  if (!existsSync(body) && /[*?\x5b\x5d{}()]/.test(body)) return selector;
+  return `${negated ? "!" : ""}${canonicalSourcePath(body)}`;
+}
 const WORKFLOW_DIRECTORY = "pi-extensible-workflows";
 function workflowSystemPromptPath(cwd: string, agentDir: string, projectTrusted: boolean): string | undefined {
   const projectPath = join(cwd, ".pi", WORKFLOW_DIRECTORY, "SYSTEM.md");
@@ -173,9 +179,11 @@ export async function createLocalPiSession(input: SessionInput): Promise<PiSessi
     const packageManager = new DefaultPackageManager({ cwd: input.cwd, agentDir, settingsManager });
     const resolved = await packageManager.resolve();
     const discoveredExtensions = [...new Set(resolved.extensions.filter(({ enabled, metadata }) => enabled && (policy.projectTrusted || metadata.scope !== "project")).map(({ path }) => canonicalSourcePath(path)))];
-    const excludedExtensions = new Set(disabledResources(policy.effective.extensions, discoveredExtensions));
+    const extensionSelectors = policy.effective.extensions.map((selector) => ({ original: selector, matching: canonicalExtensionSelector(selector) }));
+    const excludedExtensions = new Set(disabledResources(extensionSelectors.map(({ matching }) => matching), discoveredExtensions));
     const extensionPaths = discoveredExtensions.filter((path) => !excludedExtensions.has(path));
-    Object.assign(policy, { excludedExtensions: [...excludedExtensions], unmatchedExtensions: unmatchedResourcePatterns(policy.effective.extensions, discoveredExtensions) });
+    const unmatchedExtensions = extensionSelectors.filter(({ matching }) => unmatchedResourcePatterns([matching], discoveredExtensions).length > 0).map(({ original }) => original);
+    Object.assign(policy, { excludedExtensions: [...excludedExtensions], unmatchedExtensions });
     const skillPaths = [...new Set(resolved.skills.filter(({ enabled, metadata }) => enabled && (policy.projectTrusted || metadata.scope !== "project")).map(({ path }) => path))];
     const updateSkillMatches = (skills: readonly { name: string }[]): Set<string> => {
       const names = [...new Set(skills.map(({ name }) => name))];

--- a/packages/core/src/ambient-workflow-evals.ts
+++ b/packages/core/src/ambient-workflow-evals.ts
@@ -292,8 +292,8 @@ export async function runAmbientPiProcess(input: AmbientPiProcessInput): Promise
       totalCost += usageCost(event.message);
       if (totalCost > input.maxCost && !budgetExceeded) {
         budgetExceeded = true;
-        controller.abort();
         void requestKill().then((terminated) => { processGroupTerminated ||= terminated; });
+        controller.abort();
       }
     } catch { /* Ignore non-JSON diagnostics in print mode. */ }
   };
@@ -310,8 +310,8 @@ export async function runAmbientPiProcess(input: AmbientPiProcessInput): Promise
   const close = new Promise<number | null>((resolve) => { child.once("close", (code) => { resolve(code); }); });
   const timer = setTimeout(() => {
     timedOut = true;
-    controller.abort();
     void requestKill().then((terminated) => { processGroupTerminated ||= terminated; });
+    controller.abort();
   }, input.timeoutMs);
   const exitCode = await close;
   clearTimeout(timer);

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { renameSync, rmSync, writeFileSync } from "node:fs";
-import { access, link, mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { access, link, mkdir, open, readFile, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 import { promisify } from "node:util";
@@ -785,8 +785,9 @@ export class RunStore {
       let worktreeCreated = false;
       try {
         const root = (await git(this.cwd, ["rev-parse", "--show-toplevel"])).trim();
-        const launchRelative = relative(root, this.cwd);
-        if (launchRelative.startsWith("..")) throw new Error("launch cwd is outside the repository");
+        const [canonicalRoot, canonicalCwd] = await Promise.all([realpath(root), realpath(this.cwd)]);
+        const launchRelative = relative(canonicalRoot, canonicalCwd);
+        if (launchRelative === ".." || launchRelative.startsWith(`..${sep}`)) throw new Error("launch cwd is outside the repository");
         await this.cleanupMarker(markerPath);
         await mkdir(dirname(path), { recursive: true, mode: 0o700 });
         await git(root, ["read-tree", "HEAD"], { GIT_INDEX_FILE: index });

--- a/packages/core/src/workflow-evals.ts
+++ b/packages/core/src/workflow-evals.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -558,7 +558,7 @@ async function runPiCapture(input: CaptureCaseInput, cwd: string, home: string, 
         if (!usage) return;
         streamCost += usage.cost;
         reportProgress(`${input.case.id}: parent turn complete, ${String(usage.totalTokens)} tokens, $${streamCost.toFixed(4)} total`);
-        if (streamCost > input.maxCost && !budgetExceeded) { budgetExceeded = true; controller.abort(); void requestKill().then((terminated) => { processGroupTerminated ||= terminated; }); }
+        if (streamCost > input.maxCost && !budgetExceeded) { budgetExceeded = true; void requestKill().then((terminated) => { processGroupTerminated ||= terminated; }); controller.abort(); }
         return;
       }
       if (event.type === "turn_end") {
@@ -583,7 +583,7 @@ async function runPiCapture(input: CaptureCaseInput, cwd: string, home: string, 
   child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString()}`.slice(-64_000); });
   child.once("error", (error: Error) => { spawnError = error.message; });
   const close = new Promise<number | null>((resolve) => { child.once("close", (code) => { resolve(code); }); });
-  const timer = input.case.timeoutMs === undefined ? undefined : setTimeout(() => { timedOut = true; controller.abort(); void requestKill().then((terminated) => { processGroupTerminated ||= terminated; }); }, input.case.timeoutMs);
+  const timer = input.case.timeoutMs === undefined ? undefined : setTimeout(() => { timedOut = true; void requestKill().then((terminated) => { processGroupTerminated ||= terminated; }); controller.abort(); }, input.case.timeoutMs);
   const exitCode = await close; if (timer) clearTimeout(timer);
   if (lineBuffer) inspectLine(lineBuffer);
   if (killPromise) processGroupTerminated ||= await killPromise;
@@ -634,14 +634,14 @@ async function runSemanticJudge(input: CaptureCaseInput, calls: readonly Capture
       const measured = usageFrom(event.message);
       if (measured) usage = addUsage(usage, { input: measured.input, output: measured.output, cacheRead: measured.cacheRead, cacheWrite: measured.cacheWrite, totalTokens: measured.totalTokens, cost: measured.cost, models: [{ model: measured.model, cost: measured.cost }] });
       if (Array.isArray(event.message.content)) raw = event.message.content.flatMap((part) => isObject(part) && part.type === "text" && typeof part.text === "string" ? [part.text] : []).join("\n");
-      if (usage.cost > maxCost && !budgetExceeded) { budgetExceeded = true; controller.abort(); void requestKill().then((terminated) => { processGroupTerminated ||= terminated; }); }
+      if (usage.cost > maxCost && !budgetExceeded) { budgetExceeded = true; void requestKill().then((terminated) => { processGroupTerminated ||= terminated; }); controller.abort(); }
     } catch { /* Ignore diagnostics in the JSON stream. */ }
   };
   child.stdout.on("data", (chunk: Buffer) => { lineBuffer += chunk.toString(); const lines = lineBuffer.split("\n"); lineBuffer = lines.pop() ?? ""; for (const line of lines) if (line) inspectLine(line); });
   child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString()}`.slice(-64_000); });
   child.once("error", (error: Error) => { spawnError = error.message; });
   const close = new Promise<number | null>((resolve) => { child.once("close", resolve); });
-  const timer = input.case.timeoutMs === undefined ? undefined : setTimeout(() => { timedOut = true; controller.abort(); void requestKill().then((terminated) => { processGroupTerminated ||= terminated; }); }, input.case.timeoutMs);
+  const timer = input.case.timeoutMs === undefined ? undefined : setTimeout(() => { timedOut = true; void requestKill().then((terminated) => { processGroupTerminated ||= terminated; }); controller.abort(); }, input.case.timeoutMs);
   const exitCode = await close; if (timer) clearTimeout(timer); if (lineBuffer) inspectLine(lineBuffer); if (killPromise) processGroupTerminated ||= await killPromise;
   return { raw, usage, exitCode, timedOut, budgetExceeded, processGroupTerminated, stoppedIntentionally: false, stderr, ...(spawnError ? { error: spawnError } : {}) };
 }
@@ -793,7 +793,7 @@ export async function captureEvalCase(input: CaptureCaseInput): Promise<EvalCase
 export interface IsolatedProcessOptions { childPath: string; timeoutMs?: number; env?: NodeJS.ProcessEnv; onStderr?: (chunk: string) => void }
 export interface IsolatedProcessResult<T> { value?: T; timedOut: boolean; exitCode: number | null; processGroupTerminated: boolean; stderr: string; error?: string }
 export async function runIsolatedProcess<T>(payload: unknown, options: IsolatedProcessOptions): Promise<IsolatedProcessResult<T>> {
-  const root = mkdtempSync(join(tmpdir(), "pi-workflow-eval-case-")); const inputPath = join(root, "input.json"); const outputPath = join(root, "output.json");
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "pi-workflow-eval-case-"))); const inputPath = join(root, "input.json"); const outputPath = join(root, "output.json");
   try {
     writeFileSync(inputPath, `${JSON.stringify({ payload, outputPath })}\n`, { mode: 0o600 });
     const controller = new AbortController();
@@ -802,7 +802,7 @@ export async function runIsolatedProcess<T>(payload: unknown, options: IsolatedP
     child.stderr.on("data", (chunk: Buffer) => { const text = chunk.toString(); stderr = `${stderr}${text}`.slice(-64_000); options.onStderr?.(text); });
     child.once("error", (error: Error) => { processError = error.message; });
     const close = new Promise<number | null>((resolve) => { child.once("close", (code) => { resolve(code); }); });
-    const timer = options.timeoutMs === undefined ? undefined : setTimeout(() => { timedOut = true; controller.abort(); killPromise ??= killProcessGroup(child); void killPromise.then((terminated) => { processGroupTerminated ||= terminated; }); }, options.timeoutMs);
+    const timer = options.timeoutMs === undefined ? undefined : setTimeout(() => { timedOut = true; killPromise ??= killProcessGroup(child); controller.abort(); void killPromise.then((terminated) => { processGroupTerminated ||= terminated; }); }, options.timeoutMs);
     const exitCode = await close; if (timer) clearTimeout(timer);
     if (killPromise) processGroupTerminated ||= await killPromise;
     if (!existsSync(outputPath)) return { timedOut, exitCode, processGroupTerminated, stderr, ...(processError ? { error: processError } : {}) };

--- a/packages/core/test/agent-execution.test.ts
+++ b/packages/core/test/agent-execution.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -1307,7 +1307,11 @@ void test("isolates role resource exclusions and reapplies them on retries", asy
   assert.deepEqual(basePolicy.effective, { skills: ["global", "project"], extensions: ["/global.ts", "/project.ts"] });
 });
 void test("filters disabled native extensions before factories and skills before session registration", async () => {
-  const rootDir = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-resource-loader-"));
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-resource-loader-"));
+  const physicalRoot = join(fixtureRoot, "physical");
+  const rootDir = join(fixtureRoot, "alias");
+  mkdirSync(physicalRoot);
+  symlinkSync(physicalRoot, rootDir, process.platform === "win32" ? "junction" : "dir");
   const agentDir = join(rootDir, "agent");
   const cwd = join(rootDir, "project");
   const projectExtensions = join(cwd, ".pi", "extensions");
@@ -1317,7 +1321,7 @@ void test("filters disabled native extensions before factories and skills before
   mkdirSync(join(agentDir, "extensions"), { recursive: true });
   writeFileSync(join(agentDir, "models.json"), JSON.stringify({ providers: {} }));
   writeFileSync(join(agentDir, "auth.json"), "{}");
-  const disabledExtension = join(agentDir, "extensions", "disabled.ts");
+  const disabledExtension = join(agentDir, "extensions", "disabled (1).ts");
   const allowedExtension = join(agentDir, "extensions", "allowed.ts");
   const disabledMarker = join(rootDir, "disabled-extension-ran");
   const allowedMarker = join(rootDir, "allowed-extension-ran");
@@ -1429,7 +1433,7 @@ void test("loads workflow SYSTEM.md with project trust and precedence", async ()
   }
 });
 void test("applies ordered minimatch resource exclusions and records concrete matches", async () => {
-  const rootDir = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-resource-globs-"));
+  const rootDir = realpathSync(mkdtempSync(join(tmpdir(), "pi-extensible-workflows-resource-globs-")));
   const agentDir = join(rootDir, "agent");
   const cwd = join(rootDir, "project");
   mkdirSync(join(agentDir, "extensions"), { recursive: true });

--- a/packages/core/test/agent-execution.test.ts
+++ b/packages/core/test/agent-execution.test.ts
@@ -1348,8 +1348,8 @@ void test("filters disabled native extensions before factories and skills before
   const session = await createLocalPiSession({ cwd, agentDir, model: { provider: "openai-codex", model: "gpt-5.6-sol" }, tools: ["read"], sessionLabel: "resource-filter", resourcePolicy, extensionFactories: [() => {}] });
   const loaded = (session as unknown as { resourceLoader: { getSkills(): { skills: Array<{ name: string }> }; getExtensions(): { extensions: Array<{ resolvedPath: string }> } } }).resourceLoader;
   const resourcePaths = (session as unknown as { herdrResourcePaths: { extensions: readonly string[]; skills: readonly string[] } }).herdrResourcePaths;
-  assert.deepEqual(resourcePaths.extensions, [resolve(allowedExtension)]);
-  assert.ok(resourcePaths.skills.includes(resolve(join(skillsDir, "kept-skill", "SKILL.md"))));
+  assert.deepEqual(resourcePaths.extensions, [realpathSync(allowedExtension)]);
+  assert.ok(resourcePaths.skills.includes(realpathSync(join(skillsDir, "kept-skill", "SKILL.md"))));
   assert.equal(resourcePaths.skills.some((path) => path.includes("disabled-skill")), false);
   assert.equal(existsSync(disabledMarker), false);
   assert.equal(existsSync(allowedMarker), true);
@@ -1360,7 +1360,7 @@ void test("filters disabled native extensions before factories and skills before
   assert.equal(skillNames.includes("disabled-skill"), false);
   assert.equal(skillNames.includes("project-disabled-skill"), false);
   assert.equal(skillNames.includes("project-kept-skill"), false);
-  assert.ok(loaded.getExtensions().extensions.every(({ resolvedPath }) => resolvedPath !== resolve(disabledExtension)));
+  assert.ok(loaded.getExtensions().extensions.every(({ resolvedPath }) => resolvedPath !== realpathSync(disabledExtension)));
   assert.match(session.systemPrompt ?? "", /kept-skill/);
   assert.doesNotMatch(session.systemPrompt ?? "", /disabled-skill/);
   const commands = (session as unknown as { _extensionRunner: { runtime: { getCommands(): Array<{ name: string }> } } })._extensionRunner.runtime.getCommands();

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { join, resolve } from "node:path";
@@ -3147,7 +3147,7 @@ void test("accepts role system prompt override metadata", () => {
   assert.throws(() => parseRoleMarkdown("---\noverrideSystemPrompt: yes\n---\nbody", true), (error: unknown) => error instanceof WorkflowError && error.code === "INVALID_METADATA");
 });
 void test("strict role resource exclusions normalize relative and portable paths", () => {
-  const root = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-role-resources-"));
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "pi-extensible-workflows-role-resources-")));
   const rolePath = join(root, "roles", "reviewer.md");
   const extension = join(root, "role-extension.ts");
   mkdirSync(join(root, "roles"), { recursive: true });
@@ -3325,7 +3325,7 @@ void test("matches Windows extension paths using portable glob separators", () =
   assert.deepEqual(disabledResources(["C:\\agent\\extensions\\**\\*.ts", `!${allowed}`], [disabled, allowed]), [disabled]);
 });
 void test("canonicalizes symlinked extension glob prefixes", () => {
-  const root = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-symlink-globs-"));
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "pi-extensible-workflows-symlink-globs-")));
   const path = join(root, "settings.json");
   const realExtensions = join(root, "real", "extensions");
   mkdirSync(realExtensions, { recursive: true });

--- a/packages/core/test/persistence.test.ts
+++ b/packages/core/test/persistence.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -320,6 +320,26 @@ void test("creates deterministic snapshot worktrees, preserves launch subdirecto
   await store.delete(true);
   assert.equal(existsSync(first.path), false);
   assert.throws(() => execFileSync("git", ["-C", repo, "rev-parse", "--verify", first.branch], { stdio: "ignore" }));
+});
+void test("creates snapshot worktrees from a symlinked repository cwd without rewriting the persisted cwd", { skip: process.platform === "win32" }, async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-symlinked-worktree-"));
+  const repo = join(home, "repo");
+  const alias = join(home, "repo-alias");
+  const repoCwd = join(repo, "packages", "app");
+  const cwd = join(alias, "packages", "app");
+  mkdirSync(repoCwd, { recursive: true });
+  execFileSync("git", ["init", "-q", repo]);
+  execFileSync("git", ["-C", repo, "config", "user.name", "test"]);
+  execFileSync("git", ["-C", repo, "config", "user.email", "test@example.com"]);
+  writeFileSync(join(repoCwd, "tracked.txt"), "initial");
+  execFileSync("git", ["-C", repo, "add", "."]);
+  execFileSync("git", ["-C", repo, "commit", "-qm", "initial"]);
+  symlinkSync(repo, alias, "dir");
+  const store = new RunStore(cwd, "session-a", "run-a", home);
+  await store.create(run(cwd), snapshot);
+  const worktree = await store.worktree("agent");
+  assert.equal(worktree.cwd, join(worktree.path, "packages", "app"));
+  assert.equal((await store.load()).run.cwd, cwd);
 });
 void test("does not advertise non-canonical named worktree owners", async () => {
   const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-non-canonical-named-worktree-"));


### PR DESCRIPTION
Rebased implementation of #165 onto current `main` (original commit `a96bc30`).

Includes a regression-test correction for canonical resource paths after the rebase.

Verified with `npm run check`.

Supersedes #165.