### PR TITLE
test: cover launch cwd containment rejection

### DIFF
--- a/packages/core/test/persistence.test.ts
+++ b/packages/core/test/persistence.test.ts
@@ -341,6 +341,36 @@ void test("creates snapshot worktrees from a symlinked repository cwd without re
   assert.equal(worktree.cwd, join(worktree.path, "packages", "app"));
   assert.equal((await store.load()).run.cwd, cwd);
 });
+void test("rejects a launch cwd outside the repository without rejecting dotted directory names", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-outside-worktree-"));
+  const repo = join(home, "repo");
+  const dotted = join(repo, "..foo");
+  mkdirSync(dotted, { recursive: true });
+  execFileSync("git", ["init", "-q", repo]);
+  execFileSync("git", ["-C", repo, "config", "user.name", "test"]);
+  execFileSync("git", ["-C", repo, "config", "user.email", "test@example.com"]);
+  writeFileSync(join(dotted, "tracked.txt"), "initial");
+  execFileSync("git", ["-C", repo, "add", "."]);
+  execFileSync("git", ["-C", repo, "commit", "-qm", "initial"]);
+  const dottedStore = new RunStore(dotted, "session-a", "run-a", home);
+  await dottedStore.create(run(dotted), snapshot);
+  const dottedWorktree = await dottedStore.worktree("agent");
+  assert.equal(dottedWorktree.cwd, join(dottedWorktree.path, "..foo"));
+  const outside = join(home, "elsewhere");
+  mkdirSync(outside);
+  const outsideStore = new RunStore(outside, "session-b", "run-b", home);
+  await outsideStore.create({ ...run(outside, "session-b"), id: "run-b" }, snapshot);
+  const previousGitDir = process.env.GIT_DIR;
+  const previousWorkTree = process.env.GIT_WORK_TREE;
+  process.env.GIT_DIR = join(repo, ".git");
+  process.env.GIT_WORK_TREE = repo;
+  try {
+    await assert.rejects(outsideStore.worktree("agent"), (error: unknown) => error instanceof WorkflowError && error.code === "WORKTREE_FAILED" && error.message.includes("launch cwd is outside the repository"));
+  } finally {
+    if (previousGitDir === undefined) delete process.env.GIT_DIR; else process.env.GIT_DIR = previousGitDir;
+    if (previousWorkTree === undefined) delete process.env.GIT_WORK_TREE; else process.env.GIT_WORK_TREE = previousWorkTree;
+  }
+});
 void test("does not advertise non-canonical named worktree owners", async () => {
   const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-non-canonical-named-worktree-"));
   const repo = join(home, "repo");


### PR DESCRIPTION
Follow-up to review point 1 on #165: the missing negative test for a genuinely outside-repository launch cwd (#161).

Covers both sides of the containment check merged in #168, in one fixture:

- a directory literally named `..foo` **inside** the repository is accepted, which the previous `launchRelative.startsWith("..")` check rejected by mistake
- a launch cwd outside the repository is rejected with `WORKTREE_FAILED` and the `launch cwd is outside the repository` message

Reaching the containment branch needs care. A cwd that simply is not in any repository fails earlier, on `git rev-parse --show-toplevel` with "not a git repository", so that variant passes against the pre-fix implementation too and proves nothing. The test instead exports `GIT_DIR`/`GIT_WORK_TREE` (restored in `finally`) so Git reports a root that is not an ancestor of the launch cwd, which is also a realistic setup when pi runs from a hook or a `rebase --exec` context.

## Verification

macOS 26.5.2, Node.js 24.18.0.

- `npm run build` and `npm run lint` in `packages/core`: pass
- `persistence.test.js` in isolation: pass
- mutation check: restoring the old `relative(root, this.cwd)` + `startsWith("..")` makes the new test fail, so it is a real regression test

Full core suite has two unrelated pre-existing failures in `runtime-acceptance.test.ts` (`running` instead of `completed`), addressed separately.