### PR TITLE
test: assert ambient timeouts leave no surviving descendants

### DIFF
--- a/packages/core/test/ambient-workflow-evals.test.ts
+++ b/packages/core/test/ambient-workflow-evals.test.ts
@@ -93,11 +93,21 @@ appendFileSync(join(process.cwd(), "src/score.js"), "\\n// edited only in this w
 
     const third = createAmbientCaseWorktree(repository, "timeout");
     const slowPi = join(fakeRoot, "slow-pi.mjs");
-    writeFileSync(slowPi, "#!/usr/bin/env node\nsetInterval(() => {}, 1_000);\n");
+    const grandchildPidFile = join(fakeRoot, "grandchild.pid");
+    writeFileSync(slowPi, `#!/usr/bin/env node\nimport { spawn } from "node:child_process";\nimport { writeFileSync } from "node:fs";\nconst grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });\nwriteFileSync(${JSON.stringify(grandchildPidFile)}, String(grandchild.pid));\nsetInterval(() => {}, 1000);\n`);
     chmodSync(slowPi, 0o755);
-    const timeout = await runAmbientPiProcess({ worktree: third.path, sessionDir: join(repository.root, "sessions", "timeout"), prompt: "ignored", provider: "fake", model: "model", piCommand: slowPi, timeoutMs: 50, maxCost: 1 });
+    const timeout = await runAmbientPiProcess({ worktree: third.path, sessionDir: join(repository.root, "sessions", "timeout"), prompt: "ignored", provider: "fake", model: "model", piCommand: slowPi, timeoutMs: 1_000, maxCost: 1 });
     assert.equal(timeout.timedOut, true);
     assert.equal(timeout.processGroupTerminated, true);
+    assert.equal(existsSync(grandchildPidFile), true, "the fake pi never spawned its grandchild before the timeout");
+    const grandchildPid = Number(readFileSync(grandchildPidFile, "utf8"));
+    assert.ok(Number.isInteger(grandchildPid) && grandchildPid > 0);
+    let grandchildAlive = true;
+    for (let attempt = 0; attempt < 200 && grandchildAlive; attempt += 1) {
+      try { process.kill(grandchildPid, 0); await new Promise((resolve) => setTimeout(resolve, 10)); } catch { grandchildAlive = false; }
+    }
+    if (grandchildAlive) try { process.kill(grandchildPid, "SIGKILL"); } catch { /* Already gone. */ }
+    assert.equal(grandchildAlive, false, "the detached process group survived the timeout");
     assert.equal(removeAmbientCaseWorktree(repository, third), true);
     assert.equal(existsSync(third.path), false);
   } finally {


### PR DESCRIPTION
Partial answer to review point 4 on #165, and it does **not** deliver the reproduction that was asked for. Please read the caveat before merging.

The existing ambient timeout test spawns a fake pi with no children, so nothing in the suite asserts that descendants actually die. This makes the fake pi spawn a grandchild in the same process group, record its pid, and asserts the grandchild is gone after the timeout. A fallback `SIGKILL` keeps a failing run from leaking a process.

## Caveat: this does not prove the kill-before-abort ordering

Mutation check on macOS 26.5.2 / Node.js 24.18.0: restoring the old order (`controller.abort()` before `requestKill()`) still passes, 3 runs out of 3, exit code 0, no failures.

`controller.abort()` only signals the direct child, and the reap does not complete before `killProcessGroup()` runs `process.kill(-pid)` on the next microtask, so the group dies either way. The race described in #159 does not reproduce here.

So this is descendant-termination coverage for a real and previously untested property, not a regression test for the ordering change. Proving the ordering would need the child-kill race to be injectable. Feel free to close this if you would rather record point 4 as not reproducible.

## Verification

- `npm run build` and `npm run lint` in `packages/core`: pass
- `ambient-workflow-evals.test.js` in isolation: pass, exit code 0