### PR TITLE
Show workflow runs live, and leave a receipt behind

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ export default tseslint.config(
     rules: { "@typescript-eslint/require-await": "off" },
   },
   {
-    files: ["packages/extensions/herdr/**/*.js", "packages/extensions/herdr/**/*.mjs", "packages/extensions/subagents/**/*.js", "packages/extensions/subagents/**/*.mjs"],
+    files: ["packages/extensions/herdr/**/*.js", "packages/extensions/herdr/**/*.mjs", "packages/extensions/subagents/**/*.js", "packages/extensions/subagents/**/*.mjs", "packages/extensions/widget/**/*.js", "packages/extensions/widget/**/*.mjs"],
     ...tseslint.configs.disableTypeChecked,
     languageOptions: {
       parserOptions: { project: false, projectService: false },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2492,6 +2492,20 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -2762,6 +2776,10 @@
     },
     "node_modules/@piewf/subagents": {
       "resolved": "packages/extensions/subagents",
+      "link": true
+    },
+    "node_modules/@piewf/widget": {
+      "resolved": "packages/extensions/widget",
       "link": true
     },
     "node_modules/@protobufjs/aspromise": {
@@ -3730,6 +3748,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3963,6 +3994,19 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -4565,6 +4609,21 @@
         "@earendil-works/pi-coding-agent": "*",
         "pi-extensible-workflows": "*",
         "typebox": "*"
+      }
+    },
+    "packages/extensions/widget": {
+      "name": "@piewf/widget",
+      "version": "5.2.0",
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "0.82.1",
+        "@earendil-works/pi-tui": "*",
+        "@types/node": "24.12.4",
+        "typescript": "5.9.3"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
+        "pi-extensible-workflows": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
     "packages/extensions/*"
   ],
   "pi": {
-    "extensions": ["./packages/core/src/index.ts"]
+    "extensions": [
+      "./packages/core/src/index.ts"
+    ]
   },
   "scripts": {
-    "build": "npm run build --workspace=packages/core && npm run build --workspace=packages/cli && npm run build --workspace=packages/extensions/herdr && npm run build --workspace=packages/extensions/subagents",
+    "build": "npm run build --workspace=packages/core && npm run build --workspace=packages/cli && npm run build --workspace=packages/extensions/herdr && npm run build --workspace=packages/extensions/subagents && npm run build --workspace=packages/extensions/widget",
     "inspect": "npm run inspect --workspace=packages/cli",
-    "lint": "npm run lint --workspace=packages/core && npm run lint --workspace=packages/cli && npm run lint --workspace=packages/extensions/herdr && npm run lint --workspace=packages/extensions/subagents",
-    "test": "npm run test --workspace=packages/core && npm run test --workspace=packages/cli && npm run test --workspace=packages/extensions/herdr && npm run test --workspace=packages/extensions/subagents && npm run test:template",
+    "lint": "npm run lint --workspace=packages/core && npm run lint --workspace=packages/cli && npm run lint --workspace=packages/extensions/herdr && npm run lint --workspace=packages/extensions/subagents && npm run lint --workspace=packages/extensions/widget",
+    "test": "npm run test --workspace=packages/core && npm run test --workspace=packages/cli && npm run test --workspace=packages/extensions/herdr && npm run test --workspace=packages/extensions/subagents && npm run test --workspace=packages/extensions/widget && npm run test:template",
     "test:run": "npm run test:run --workspace=packages/core && npm run test:herdr --workspace=packages/core && npm run test:run --workspace=packages/cli",
     "test:template": "node --test --test-timeout=10000 --test-force-exit packages/core/examples/workflow-extension-template/extension.test.mjs",
     "acceptance": "npm run acceptance --workspace=packages/core",

--- a/packages/core/src/agent-execution.ts
+++ b/packages/core/src/agent-execution.ts
@@ -209,6 +209,30 @@ async function preparePiPrompt(native: PiSession, text: string): Promise<PiPromp
 
 interface LocalPiSessionHandle { readonly session: PiSession; shutdown(reason: LocalSessionShutdownReason, targetSessionFile?: string): Promise<void> }
 export async function createLocalPiSession(input: SessionInput): Promise<PiSession> { return (await createLocalPiSessionHandle(input)).session; }
+/**
+ * Hands the runtime the providers that extensions registered while loading.
+ *
+ * An extension that adds models (a proxy front-end, a gateway) registers them
+ * from its factory, and the loader parks those registrations on the extension
+ * runtime rather than applying them. Pi's own session assembly drains that
+ * queue; a workflow agent builds its runtime here by hand, so without this the
+ * models an extension provides stay unknown and every agent asking for one
+ * fails with UNKNOWN_MODEL.
+ */
+function flushExtensionProviders(resourceLoader: DefaultResourceLoader, modelRuntime: ModelRuntime): void {
+  const { runtime } = resourceLoader.getExtensions();
+  for (const { name, config } of runtime.pendingProviderRegistrations) {
+    // A provider that cannot be registered must not stop the agent from
+    // starting: the model it offers may not be the one this agent asked for.
+    try { modelRuntime.registerProvider(name, config); } catch { /* Reported when the model itself turns out to be missing. */ }
+  }
+  runtime.pendingProviderRegistrations = [];
+  for (const { provider } of runtime.pendingNativeProviderRegistrations) {
+    try { modelRuntime.registerNativeProvider(provider); } catch { /* Same. */ }
+  }
+  runtime.pendingNativeProviderRegistrations = [];
+}
+
 async function createLocalPiSessionHandle(input: SessionInput, sessionStartEvent?: SessionStartEvent): Promise<LocalPiSessionHandle> {
   const agentDir = input.agentDir ?? getAgentDir();
   const systemPromptSource = workflowSystemPromptPath(input.cwd, agentDir, input.resourcePolicy?.projectTrusted ?? true);
@@ -217,8 +241,6 @@ async function createLocalPiSessionHandle(input: SessionInput, sessionStartEvent
   const manager = input.sessionManager ?? (input.sessionPath ? SessionManager.open(input.sessionPath, join(agentDir, "sessions"), input.cwd) : input.agentDir ? SessionManager.create(input.cwd, join(agentDir, "sessions")) : SessionManager.create(input.cwd));
   if (!input.sessionPath) manager.appendSessionInfo(input.sessionLabel);
   const modelRuntime = await ModelRuntime.create({ authPath: join(agentDir, "auth.json"), modelsPath: join(agentDir, "models.json") });
-  const model = modelRuntime.getModel(input.model.provider, input.model.model);
-  if (!model) throw new WorkflowError("UNKNOWN_MODEL", `Unknown model: ${input.model.provider}/${input.model.model}`);
   const customTools = [...(input.customTools ?? []), ...(input.resultTool ? [input.resultTool] : [])];
   const tools = [...new Set([...input.tools, ...customTools.map(({ name }) => name)])];
   let settingsManager: SettingsManager;
@@ -268,6 +290,10 @@ async function createLocalPiSessionHandle(input: SessionInput, sessionStartEvent
     resourceLoader = new DefaultResourceLoader({ cwd: input.cwd, agentDir, settingsManager, noExtensions: true, additionalExtensionPaths: extensionPaths, ...(input.additionalSkillPaths?.length ? { additionalSkillPaths: [...input.additionalSkillPaths] } : {}), ...(input.extensionFactories?.length ? { extensionFactories: input.extensionFactories } : {}), ...(contextFilesOverride ? { agentsFilesOverride: contextFilesOverride } : {}), ...systemPromptOptions, ...(input.systemPromptAppend ? { appendSystemPromptOverride: (base) => [...base, input.systemPromptAppend ?? ""] } : {}) });
     await resourceLoader.reload();
   }
+  flushExtensionProviders(resourceLoader, modelRuntime);
+  await modelRuntime.refresh({ allowNetwork: false });
+  const model = modelRuntime.getModel(input.model.provider, input.model.model);
+  if (!model) throw new WorkflowError("UNKNOWN_MODEL", `Unknown model: ${input.model.provider}/${input.model.model}`);
   const { session } = await createAgentSession({ ...(input.options ?? {}), cwd: input.cwd, agentDir, modelRuntime, model, settingsManager, ...(input.model.thinking ? { thinkingLevel: input.model.thinking } : {}), tools, ...(customTools.length ? { customTools } : {}), ...(input.extensionFactories?.length ? { extensionFactories: input.extensionFactories } : {}), resourceLoader, ...(sessionStartEvent ? { sessionStartEvent } : {}), sessionManager: manager });
   const nativeDispose = session.dispose.bind(session);
   let disposal: Promise<void> | undefined;

--- a/packages/core/src/agent-execution.ts
+++ b/packages/core/src/agent-execution.ts
@@ -4,8 +4,10 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Type } from "@earendil-works/pi-ai";
 import { Compile } from "typebox/compile";
-import { createAgentSession, DefaultPackageManager, DefaultResourceLoader, defineTool, getAgentDir, ModelRuntime, SessionManager, SettingsManager, type SessionStartEvent, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, DefaultPackageManager, DefaultResourceLoader, defineTool, getAgentDir, ModelRuntime, SessionManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext, ModelRegistry, SessionStartEvent, ToolDefinition } from "@earendil-works/pi-coding-agent";
 type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+type HerdrModelContext = { readonly model: ExtensionContext["model"]; readonly modelRegistry: ModelRegistry | undefined };
 type AgentMessage = { role: string; content?: unknown; stopReason?: string; errorMessage?: string; usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: { total: number } } };
 type LocalSessionShutdownReason = "quit" | "resume";
 export interface PiSession {
@@ -15,6 +17,7 @@ export interface PiSession {
   getSessionStats(): { tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number }; cost: number };
   readonly systemPrompt?: string;
   readonly model?: { provider: string; model?: string; id?: string } | undefined;
+  readonly herdrModelContext?: HerdrModelContext;
   readonly thinkingLevel?: string;
   readonly agent?: { state: { tools: readonly { name: string }[] }; subscribe?(listener: (event: unknown) => void | Promise<void>): () => void };
   readonly herdrResourcePaths?: { extensions: readonly string[]; skills: readonly string[] };
@@ -238,7 +241,7 @@ export function flushExtensionProviders(resourceLoader: DefaultResourceLoader, m
     try {
       modelRuntime.registerNativeProvider(provider);
     } catch (error) {
-      failures.push(`native provider: ${error instanceof Error ? error.message : String(error)}`);
+      failures.push(`${provider.id || "native provider"}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
   runtime.pendingNativeProviderRegistrations = [];
@@ -347,6 +350,7 @@ async function createLocalPiSessionHandle(input: SessionInput, sessionStartEvent
     getToolDefinitions: () => session.getAllTools().map(({ name, description, parameters, promptGuidelines }) => ({ name, description, parameters, ...(promptGuidelines ? { promptGuidelines } : {}) })),
     preparePrompt: (text: string) => preparePiPrompt(session as unknown as PiSession, text),
     getResourceInspection: resourceInspection,
+    herdrModelContext: { model: session.model, modelRegistry: session.extensionRunner.getModelRegistry() },
     herdrResourcePaths: resourcePaths,
     herdrContextFiles: resourceLoader.getAgentsFiles().agentsFiles,
   }) as unknown as PiSession;
@@ -548,6 +552,7 @@ export async function createLocalWorkflowAgentSession(prepared: Readonly<Prepare
     reference,
     getHerdrResourcePaths: () => native.herdrResourcePaths,
     getHerdrContextFiles: () => native.herdrContextFiles,
+    getHerdrModelContext: () => native.herdrModelContext,
     getState: () => Object.freeze(workflowAgentState(native, prepared)),
     getSessionStats: () => workflowAgentStats(native.getSessionStats()),
     getLastAssistant: () => latestUsableAssistant(native.messages),

--- a/packages/core/src/agent-execution.ts
+++ b/packages/core/src/agent-execution.ts
@@ -219,18 +219,30 @@ export async function createLocalPiSession(input: SessionInput): Promise<PiSessi
  * models an extension provides stay unknown and every agent asking for one
  * fails with UNKNOWN_MODEL.
  */
-function flushExtensionProviders(resourceLoader: DefaultResourceLoader, modelRuntime: ModelRuntime): void {
+export function flushExtensionProviders(resourceLoader: DefaultResourceLoader, modelRuntime: ModelRuntime): string[] {
   const { runtime } = resourceLoader.getExtensions();
+  const failures: string[] = [];
   for (const { name, config } of runtime.pendingProviderRegistrations) {
     // A provider that cannot be registered must not stop the agent from
     // starting: the model it offers may not be the one this agent asked for.
-    try { modelRuntime.registerProvider(name, config); } catch { /* Reported when the model itself turns out to be missing. */ }
+    // The reason is kept, though — if the model does turn out to be missing,
+    // "unknown model" alone sends the reader looking in the wrong place.
+    try {
+      modelRuntime.registerProvider(name, config);
+    } catch (error) {
+      failures.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
   runtime.pendingProviderRegistrations = [];
   for (const { provider } of runtime.pendingNativeProviderRegistrations) {
-    try { modelRuntime.registerNativeProvider(provider); } catch { /* Same. */ }
+    try {
+      modelRuntime.registerNativeProvider(provider);
+    } catch (error) {
+      failures.push(`native provider: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
   runtime.pendingNativeProviderRegistrations = [];
+  return failures;
 }
 
 async function createLocalPiSessionHandle(input: SessionInput, sessionStartEvent?: SessionStartEvent): Promise<LocalPiSessionHandle> {
@@ -290,10 +302,17 @@ async function createLocalPiSessionHandle(input: SessionInput, sessionStartEvent
     resourceLoader = new DefaultResourceLoader({ cwd: input.cwd, agentDir, settingsManager, noExtensions: true, additionalExtensionPaths: extensionPaths, ...(input.additionalSkillPaths?.length ? { additionalSkillPaths: [...input.additionalSkillPaths] } : {}), ...(input.extensionFactories?.length ? { extensionFactories: input.extensionFactories } : {}), ...(contextFilesOverride ? { agentsFilesOverride: contextFilesOverride } : {}), ...systemPromptOptions, ...(input.systemPromptAppend ? { appendSystemPromptOverride: (base) => [...base, input.systemPromptAppend ?? ""] } : {}) });
     await resourceLoader.reload();
   }
-  flushExtensionProviders(resourceLoader, modelRuntime);
+  const providerFailures = flushExtensionProviders(resourceLoader, modelRuntime);
   await modelRuntime.refresh({ allowNetwork: false });
   const model = modelRuntime.getModel(input.model.provider, input.model.model);
-  if (!model) throw new WorkflowError("UNKNOWN_MODEL", `Unknown model: ${input.model.provider}/${input.model.model}`);
+  if (!model) {
+    // A provider that failed to register is the likeliest reason its models are
+    // missing, so the failure travels with the complaint rather than being
+    // swallowed — otherwise a misconfigured gateway reads as a typo in a model
+    // name.
+    const because = providerFailures.length > 0 ? ` (provider registration failed — ${providerFailures.join("; ")})` : "";
+    throw new WorkflowError("UNKNOWN_MODEL", `Unknown model: ${input.model.provider}/${input.model.model}${because}`);
+  }
   const { session } = await createAgentSession({ ...(input.options ?? {}), cwd: input.cwd, agentDir, modelRuntime, model, settingsManager, ...(input.model.thinking ? { thinkingLevel: input.model.thinking } : {}), tools, ...(customTools.length ? { customTools } : {}), ...(input.extensionFactories?.length ? { extensionFactories: input.extensionFactories } : {}), resourceLoader, ...(sessionStartEvent ? { sessionStartEvent } : {}), sessionManager: manager });
   const nativeDispose = session.dispose.bind(session);
   let disposal: Promise<void> | undefined;

--- a/packages/core/test/agent-execution.test.ts
+++ b/packages/core/test/agent-execution.test.ts
@@ -2285,7 +2285,6 @@ void test("models registered by an extension are available to the agent", async 
   // which is the whole point — an extension that supplies models (a proxy
   // front-end, a gateway) registers them while its resources load, and the
   // loader parks those registrations rather than applying them.
-  writeFileSync(join(agentDir, "models.json"), JSON.stringify({ providers: {} }));
   writeFileSync(join(agentDir, "auth.json"), "{}");
 
   const extensionFactory: NonNullable<SessionInput["extensionFactories"]>[number] = (pi) => {
@@ -2298,13 +2297,35 @@ void test("models registered by an extension are available to the agent", async 
   };
 
   try {
-    const session = await createLocalPiSession({ cwd, agentDir, model: { provider: "proxied", model: "proxied-model" }, tools: [], sessionLabel: "extension-provider", extensionFactories: [extensionFactory] });
+    const session = await localAgentTransport.createSession({ cwd, agentDir, model: { provider: "proxied", model: "proxied-model" }, tools: [], sessionLabel: "extension-provider", extensionFactories: [extensionFactory] }, {} as never);
     await session.dispose();
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
 
+void test("includes failed extension provider registration in createLocalPiSession UNKNOWN_MODEL", async () => {
+  const rootDir = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-provider-failure-integration-"));
+  const agentDir = join(rootDir, "agent");
+  const cwd = join(rootDir, "project");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(cwd, { recursive: true });
+  writeFileSync(join(agentDir, "auth.json"), "{}");
+  let session: Awaited<ReturnType<typeof createLocalPiSession>> | undefined;
+  const extensionFactory: NonNullable<SessionInput["extensionFactories"]>[number] = (pi) => {
+    pi.registerProvider("broken", { models: [{ id: "broken-model", name: "Broken model", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1_024, maxTokens: 128 }] });
+  };
+
+  try {
+    await assert.rejects(
+      async () => { session = await createLocalPiSession({ cwd, agentDir, model: { provider: "broken", model: "missing" }, tools: [], sessionLabel: "provider-failure", extensionFactories: [extensionFactory] }); },
+      (error: unknown) => error instanceof WorkflowError && error.code === "UNKNOWN_MODEL" && error.message.includes("provider registration failed") && error.message.includes("broken"),
+    );
+  } finally {
+    await session?.dispose();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
 void test("a provider that fails to register has its reason kept, not swallowed", () => {
   // Swallowing the failure leaves "Unknown model: acme/fast", which reads as a
   // typo in a model name and sends the reader to the wrong file. Why the models
@@ -2326,4 +2347,11 @@ void test("a provider that fails to register has its reason kept, not swallowed"
   // way, so a second agent does not retry the same failures.
   assert.deepEqual(runtime.pendingProviderRegistrations, []);
   assert.deepEqual(runtime.pendingNativeProviderRegistrations, []);
+});
+
+void test("names a native provider in registration diagnostics", () => {
+  const runtime = { pendingProviderRegistrations: [], pendingNativeProviderRegistrations: [{ provider: { id: "native-acme" } }] };
+  const resourceLoader = { getExtensions: () => ({ runtime }) } as unknown as DefaultResourceLoader;
+  const modelRuntime = { registerNativeProvider: () => { throw new Error("native failure"); } } as unknown as ModelRuntime;
+  assert.deepEqual(flushExtensionProviders(resourceLoader, modelRuntime), ["native-acme: native failure"]);
 });

--- a/packages/core/test/agent-execution.test.ts
+++ b/packages/core/test/agent-execution.test.ts
@@ -2274,3 +2274,32 @@ void test("preserves terminal progress when usage becomes unavailable", async ()
   assert.equal(terminal.persist, true);
   assert.deepEqual(terminal.accounting, { input: 2, output: 3, cacheRead: 4, cacheWrite: 5, cost: 0.25 });
 });
+void test("models registered by an extension are available to the agent", async () => {
+  const rootDir = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-extension-provider-"));
+  const agentDir = join(rootDir, "agent");
+  const cwd = join(rootDir, "project");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(cwd, { recursive: true });
+  // No provider on disk: the only route to this model is the extension below,
+  // which is the whole point — an extension that supplies models (a proxy
+  // front-end, a gateway) registers them while its resources load, and the
+  // loader parks those registrations rather than applying them.
+  writeFileSync(join(agentDir, "models.json"), JSON.stringify({ providers: {} }));
+  writeFileSync(join(agentDir, "auth.json"), "{}");
+
+  const extensionFactory: NonNullable<SessionInput["extensionFactories"]>[number] = (pi) => {
+    pi.registerProvider("proxied", {
+      baseUrl: "http://127.0.0.1:1/v1",
+      api: "openai-completions",
+      apiKey: "fixture",
+      models: [{ id: "proxied-model", name: "Proxied model", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1_024, maxTokens: 128 }],
+    });
+  };
+
+  try {
+    const session = await createLocalPiSession({ cwd, agentDir, model: { provider: "proxied", model: "proxied-model" }, tools: [], sessionLabel: "extension-provider", extensionFactories: [extensionFactory] });
+    await session.dispose();
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/test/agent-execution.test.ts
+++ b/packages/core/test/agent-execution.test.ts
@@ -5,7 +5,8 @@ import { join, resolve } from "node:path";
 import { createServer } from "node:http";
 import test from "node:test";
 import { Type } from "@earendil-works/pi-ai";
-import { createLocalPiSession, FairAgentScheduler, localAgentTransport, prepareAgentSetupForInspection, WorkflowAgentExecutor, type AgentExecutionRoot, type AgentProgress, type SessionInput } from "../src/agent-execution.js";
+import type { DefaultResourceLoader, ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { createLocalPiSession, FairAgentScheduler, flushExtensionProviders, localAgentTransport, prepareAgentSetupForInspection, WorkflowAgentExecutor, type AgentExecutionRoot, type AgentProgress, type SessionInput } from "../src/agent-execution.js";
 import { AgentSession } from "@earendil-works/pi-coding-agent";
 import { WorkflowError, roleNameOf, type AgentExecutionResult, type AgentToolCallProgress } from "../src/index.js";
 import type { AgentResourcePolicy } from "../src/types.js";
@@ -2302,4 +2303,27 @@ void test("models registered by an extension are available to the agent", async 
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
+});
+
+void test("a provider that fails to register has its reason kept, not swallowed", () => {
+  // Swallowing the failure leaves "Unknown model: acme/fast", which reads as a
+  // typo in a model name and sends the reader to the wrong file. Why the models
+  // are missing is the useful half of the message.
+  const runtime = {
+    pendingProviderRegistrations: [{ name: "acme", config: {} }],
+    pendingNativeProviderRegistrations: [{ provider: {} }],
+  };
+  const resourceLoader = { getExtensions: () => ({ runtime }) } as unknown as DefaultResourceLoader;
+  const modelRuntime = {
+    registerProvider: () => { throw new Error("baseUrl is not a valid URL"); },
+    registerNativeProvider: () => { throw new Error("already registered"); },
+  } as unknown as ModelRuntime;
+
+  const failures = flushExtensionProviders(resourceLoader, modelRuntime);
+
+  assert.deepEqual(failures, ["acme: baseUrl is not a valid URL", "native provider: already registered"]);
+  // One bad provider must not strand the others: the queue is drained either
+  // way, so a second agent does not retry the same failures.
+  assert.deepEqual(runtime.pendingProviderRegistrations, []);
+  assert.deepEqual(runtime.pendingNativeProviderRegistrations, []);
 });

--- a/packages/extensions/herdr/index.ts
+++ b/packages/extensions/herdr/index.ts
@@ -44,7 +44,8 @@ import type {
 type HerdrSettings = Pick<WorkflowSettings, "extensions">;
 type HerdrConfig = NonNullable<NonNullable<HerdrSettings["extensions"]>["herdr"]>;
 type HerdrResourcePaths = { extensions: readonly string[]; skills: readonly string[] };
-type HerdrSession = Omit<WorkflowAgentSession, "getLastAssistant" | "abort"> & { getLastAssistant?(): WorkflowAgentMessage | undefined; abort(): Promise<void>; getHerdrResourcePaths?(): HerdrResourcePaths | undefined; getHerdrContextFiles?(): readonly ContextFile[] | undefined };
+type HerdrModelContext = { readonly model: ExtensionContext["model"]; readonly modelRegistry: ModelRegistry | undefined };
+type HerdrSession = Omit<WorkflowAgentSession, "getLastAssistant" | "abort"> & { getLastAssistant?(): WorkflowAgentMessage | undefined; abort(): Promise<void>; getHerdrResourcePaths?(): HerdrResourcePaths | undefined; getHerdrContextFiles?(): readonly ContextFile[] | undefined; getHerdrModelContext?(): HerdrModelContext | undefined };
 type SessionReference = Parameters<HerdrAgentReporter["reportSession"]>[0];
 type ToolCallContent = { type: "toolCall"; name?: string };
 type LifecycleState = "idle" | "working" | "blocked";
@@ -133,16 +134,24 @@ async function createBridgeContext(session: HerdrSession, prepared: Readonly<Pre
   const reference = session.reference;
   const path = sessionPath(reference);
   const sessionManager = path && existsSync(path) ? SessionManager.open(path, undefined, prepared.cwd) : SessionManager.inMemory(prepared.cwd, { id: reference.sessionId });
-  const directory = prepared.agentDir ?? agentDir();
-  const modelRuntime = await ModelRuntime.create({ authPath: join(directory, "auth.json"), modelsPath: join(directory, "models.json") });
-  const modelRegistry = new ModelRegistry(modelRuntime);
-  const model = modelRegistry.find(prepared.model.provider, prepared.model.model);
+  const shared = session.getHerdrModelContext?.();
+  let fallbackRegistry: ModelRegistry | undefined;
+  if (shared?.modelRegistry === undefined) {
+    const directory = prepared.agentDir ?? agentDir();
+    const modelRuntime = await ModelRuntime.create({ authPath: join(directory, "auth.json"), modelsPath: join(directory, "models.json") });
+    fallbackRegistry = new ModelRegistry(modelRuntime);
+  }
+  const modelRegistry = shared?.modelRegistry ?? fallbackRegistry;
+  if (modelRegistry === undefined) throw new Error("Herdr cannot bridge tools without the local model registry.");
+  const model = shared?.model ?? modelRegistry.find(prepared.model.provider, prepared.model.model);
   const runner = new ExtensionRunner([], createExtensionRuntime(), prepared.cwd, sessionManager, modelRegistry);
   runner.setUIContext(undefined, "tui");
   const baseContext = runner.createContext();
   return (signal, abort) => new Proxy(baseContext, {
     get(target, property, receiver) {
-      if (property === "model") return model;
+      const current = session.getHerdrModelContext?.();
+      if (property === "model") return current?.model ?? model;
+      if (property === "modelRegistry") return current?.modelRegistry ?? modelRegistry;
       if (property === "thinkingLevel") return prepared.model.thinking;
       if (property === "isIdle") return () => false;
       if (property === "isProjectTrusted") return () => prepared.resourcePolicy?.projectTrusted ?? true;

--- a/packages/extensions/herdr/test/index.test.mjs
+++ b/packages/extensions/herdr/test/index.test.mjs
@@ -934,17 +934,22 @@ void test("relays generated tool bridge results, errors, and updates", async () 
   };
   const workspaces = { open: async (_run, request) => { const commandFile = /sh '([^']+)'$/.exec(request.command)?.[1]; runCommand = commandFile ? readFileSync(commandFile, "utf8") : request.command; return { workspaceId: "workspace", tabId: "tab", paneId: "pane" }; } };
   const calls = [];
-  const tool = { name: "bridge", label: "Bridge", description: "Bridge", parameters: { type: "object", properties: {}, additionalProperties: false }, async execute(toolCallId, params, _signal, onUpdate) {
+  let bridgeContext;
+  const tool = { name: "bridge", label: "Bridge", description: "Bridge", parameters: { type: "object", properties: {}, additionalProperties: false }, async execute(toolCallId, params, _signal, onUpdate, context) {
+    bridgeContext = context;
     calls.push({ toolCallId, params });
     if (params.mode === "error") throw new Error("tool failed");
     onUpdate({ state: "working" });
     return { content: [{ type: "text", text: "tool result" }] };
   } };
   const herdr = createHerdrExtension({ agentDir, env: { HERDR_ENV: "1", HERDR_SOCKET_PATH: "/tmp/herdr.sock", HERDR_PANE_ID: "parent" }, runner, workspaces });
-  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "session", locator: { sessionFile: "/tmp/herdr-test.jsonl" } }, getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }), abort: async () => {}, dispose: async () => {} }; } } };
+  const resolvedModel = { provider: "inline-only", id: "inline-model" };
+  const resolvedRegistry = { find: (provider, model) => provider === resolvedModel.provider && model === resolvedModel.id ? resolvedModel : undefined };
+  // The shared registry can arrive before the live session exposes its model.
+  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "session", locator: { sessionFile: "/tmp/herdr-test.jsonl" } }, getState: () => ({ model: value.model, tools: value.tools }), getHerdrModelContext: () => ({ model: undefined, modelRegistry: resolvedRegistry }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }), abort: async () => {}, dispose: async () => {} }; } } };
   const controller = new AbortController();
   herdr.agentSetupHooks.fullyInspectable.setup(agent, { identity: { structuralPath: ["review"], parentBreadcrumb: "flow", callSite: "agent", occurrence: 1 }, run: { runId: "run", workflow: { name: "flow" } }, signal: controller.signal });
-  const prepared = { cwd: "/repo", model: { provider: "fake", model: "model" }, tools: [], customTools: [tool], initialPrompt: "work", sessionLabel: "flow:review", piRuntime };
+  const prepared = { cwd: "/repo", model: { provider: "inline-only", model: "inline-model" }, tools: [], customTools: [tool], initialPrompt: "work", sessionLabel: "flow:review", piRuntime };
   const session = await agent.transport.createSession(prepared, { attempt: 1, signal: controller.signal });
   try {
     assert.ok(runCommand);
@@ -959,7 +964,56 @@ void test("relays generated tool bridge results, errors, and updates", async () 
     assert.deepEqual(result, { content: [{ type: "text", text: "tool result" }] });
     assert.deepEqual(updates, [{ state: "working" }]);
     assert.deepEqual(calls, [{ toolCallId: "success-call", params: { mode: "success" } }]);
+    assert.equal(bridgeContext.model, resolvedModel);
+    assert.equal(bridgeContext.modelRegistry, resolvedRegistry);
     await assert.rejects(registered[0].execute("error-call", { mode: "error" }, controller.signal, () => {}), /tool failed/);
     assert.deepEqual(calls.at(-1), { toolCallId: "error-call", params: { mode: "error" } });
   } finally { controller.abort(); await session.dispose(); await rm(root, { recursive: true, force: true }); }
+});
+
+void test("bridges a custom tool with a model supplied only by an inline extension", async () => {
+  const root = mkdtempSync(join(tmpdir(), "herdr-inline-provider-"));
+  const agentDir = join(root, "agent");
+  mkdirSync(join(agentDir, "pi-extensible-workflows"), { recursive: true });
+  writeFileSync(join(agentDir, "pi-extensible-workflows", "settings.json"), JSON.stringify({ extensions: { herdr: { enableFullyInspectableMode: true } } }));
+  writeFileSync(join(agentDir, "auth.json"), "{}");
+  let runCommand;
+  const runner = async (args) => {
+    if (args[0] === "pane" && args[1] === "process-info") return JSON.stringify({ result: { process_info: { foreground_processes: [{ name: "node", argv: [process.execPath, piRuntime.entrypoint] }] } } });
+    if (args[0] === "agent" && args[1] === "get") return JSON.stringify({ result: { agent: { agent_status: "working" } } });
+    return "";
+  };
+  const workspaces = { open: async (_run, request) => { const commandFile = /sh '([^']+)'$/.exec(request.command)?.[1]; runCommand = commandFile ? readFileSync(commandFile, "utf8") : request.command; return { workspaceId: "workspace", tabId: "tab", paneId: "pane" }; } };
+  let bridgeContext;
+  const tool = { name: "bridge", label: "Bridge", description: "Bridge", parameters: { type: "object", properties: {}, additionalProperties: false }, async execute(_id, _params, _signal, _onUpdate, context) { bridgeContext = context; return { content: [{ type: "text", text: "ok" }] }; } };
+  const extensionFactory = (pi) => {
+    pi.registerProvider("inline-only", {
+      baseUrl: "http://127.0.0.1:1/v1",
+      api: "openai-completions",
+      apiKey: "fixture",
+      models: [{ id: "inline-model", name: "Inline model", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1_024, maxTokens: 128 }],
+    });
+  };
+  const herdr = createHerdrExtension({ agentDir, env: { HERDR_ENV: "1", HERDR_SOCKET_PATH: "/tmp/herdr.sock", HERDR_PANE_ID: "parent" }, runner, workspaces });
+  const agent = { transport: { id: "local", createSession: (prepared, context) => localAgentTransport.createSession(prepared, context) } };
+  const controller = new AbortController();
+  herdr.agentSetupHooks.fullyInspectable.setup(agent, { identity: { structuralPath: ["review"], parentBreadcrumb: "flow", callSite: "agent", occurrence: 1 }, run: { runId: "run", workflow: { name: "flow" } }, signal: controller.signal });
+  const prepared = { cwd: root, agentDir, model: { provider: "inline-only", model: "inline-model" }, tools: [], customTools: [tool], extensionFactories: [extensionFactory], initialPrompt: "work", sessionLabel: "flow:review", piRuntime };
+  const session = await agent.transport.createSession(prepared, { attempt: 1, signal: controller.signal });
+  try {
+    assert.ok(runCommand);
+    const extensionPath = /--extension '([^']*pi-herdr-tools-[^']+\.mjs)'/.exec(runCommand)?.[1];
+    assert.ok(extensionPath);
+    const bridgeModule = await import(pathToFileURL(extensionPath).href);
+    let registered;
+    bridgeModule.default({ registerTool(candidate) { registered = candidate; } });
+    await registered.execute("inline-call", {}, controller.signal, () => {});
+    assert.equal(bridgeContext.model?.provider, "inline-only");
+    assert.equal(bridgeContext.model?.id, "inline-model");
+    assert.deepEqual(bridgeContext.modelRegistry.find("inline-only", "inline-model"), bridgeContext.model);
+  } finally {
+    controller.abort();
+    await session.dispose();
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/extensions/widget/README.md
+++ b/packages/extensions/widget/README.md
@@ -1,0 +1,58 @@
+# @piewf/widget
+
+A live view of workflow runs above the editor, and a durable receipt in the
+transcript once each one finishes.
+
+While a run is going, the widget draws it as a tree — phases, the agents inside
+them, the model each one is using, tokens and cost as they accrue, and a clock.
+When the run ends the widget drops it immediately and writes a receipt into the
+transcript instead:
+
+```
+✓ smoke 61.2kt · $0.09 · 01:23 · completed
+├─ ✓ shell
+├─ ✓ llm  61.2kt · $0.09
+│  ╰─ ✓ scout fixture-model:medium · $0.09 · 01:02
+│       role scout · via scout-model · read grep find ls bash
+│       in 60.4kt · out 823t · cache 203.3kt
+╰─ ✓ done
+```
+
+The split is deliberate. The widget answers *what is happening* and holds
+nothing that already happened; the receipt answers *what did it cost and who did
+it*, and keeps the answer for the life of the session rather than for a minute.
+
+## Install
+
+```sh
+npm install @piewf/widget
+```
+
+Then enable it like any other Pi extension. It needs no configuration.
+
+## What the receipt records
+
+Everything the run directory knows and the widget has no room for:
+
+- the phases in order, and which agents ran in each
+- per-agent model and thinking level, plus the role and the alias it asked for
+- the tools the role granted — the check that a read-only agent really was
+- the token split (input, output, cache reads), which is what explains a cheap
+  run that looks enormous
+- retries, since a run that only succeeded on the third attempt cost three times
+  what its final attempt suggests
+- the failure reason, when there is one
+
+The run id is only useful when acting on it, so it stays hidden until the entry
+is expanded.
+
+## How it stays cheap
+
+Run state arrives as workflow events (`workflow:run-started`,
+`workflow:agent-state-changed`, and friends). The numbers behind it live only in
+the run's `state.json`, so an event is a signal to re-read rather than the data
+itself. Between events nothing is read at all: the repaint timer only turns the
+spinner and advances the clocks.
+
+The widget belongs to its session — a run started in another window is another
+window's business, and is ignored here.

--- a/packages/extensions/widget/README.md
+++ b/packages/extensions/widget/README.md
@@ -1,21 +1,21 @@
 # @piewf/widget
 
-A live view of workflow runs above the editor, and a durable receipt in the
-transcript once each one finishes.
+A live view of workflow runs below the editor, and a durable receipt in the
+transcript once each one reaches a terminal state.
 
 While a run is going, the widget draws it as a tree — phases, the agents inside
 them, the model each one is using, tokens and cost as they accrue, and a clock.
-When the run ends the widget drops it immediately and writes a receipt into the
-transcript instead:
+When the run reaches `completed`, `failed`, or `stopped`, the widget drops it and
+writes a receipt into the transcript instead. `interrupted` and `budget_exhausted`
+runs remain visible because they can be resumed:
 
 ```
 ✓ smoke 61.2kt · $0.09 · 01:23 · completed
 ├─ ✓ shell
-├─ ✓ llm  61.2kt · $0.09
-│  ╰─ ✓ scout fixture-model:medium · $0.09 · 01:02
-│       role scout · via scout-model · read grep find ls bash
-│       in 60.4kt · out 823t · cache 203.3kt
-╰─ ✓ done
+╰─ ✓ llm  61.2kt · $0.09
+   ╰─ ✓ scout fixture-model:medium · $0.09 · 01:02
+        role scout · via scout-model · read grep find ls bash
+        in 60.4kt · out 823t · cache 203.3kt
 ```
 
 The split is deliberate. The widget answers *what is happening* and holds
@@ -36,7 +36,8 @@ Everything the run directory knows and the widget has no room for:
 
 - the phases in order, and which agents ran in each
 - per-agent model and thinking level, plus the role and the alias it asked for
-- the tools the role granted — the check that a read-only agent really was
+- the granted tool names recorded directly on each agent — the check that a read-only agent really was
+  (the list is persisted state, not a count parsed from a transcript)
 - the token split (input, output, cache reads), which is what explains a cheap
   run that looks enormous
 - retries, since a run that only succeeded on the third attempt cost three times
@@ -51,8 +52,8 @@ is expanded.
 Run state arrives as workflow events (`workflow:run-started`,
 `workflow:agent-state-changed`, and friends). The numbers behind it live only in
 the run's `state.json`, so an event is a signal to re-read rather than the data
-itself. Between events nothing is read at all: the repaint timer only turns the
-spinner and advances the clocks.
+itself. The repaint timer checks for changed state files and updates the spinner
+and clocks without reparsing unchanged runs.
 
 The widget belongs to its session — a run started in another window is another
 window's business, and is ignored here.

--- a/packages/extensions/widget/index.ts
+++ b/packages/extensions/widget/index.ts
@@ -1,16 +1,17 @@
 /**
- * Live workflow widget: a tree of the runs happening right now, drawn above the
- * editor, and a durable receipt in the transcript once each one finishes.
+ * Live workflow widget: a tree of the runs happening right now, drawn below the
+ * editor, and a durable receipt in the transcript once each one reaches a
+ * terminal state.
  *
  * The split is deliberate. The widget answers "what is happening" and holds
- * nothing that has already happened — a finished run disappears from it at
- * once. The transcript entry answers "what did that cost and who did it", and
- * keeps the answer for the life of the session rather than for a minute.
+ * nothing that has reached a final state — resumable interruptions remain visible.
+ * The transcript entry answers "what did that cost and who did it", and keeps the
+ * answer for the life of the session rather than for a minute.
  *
  * Run state arrives as workflow events; the numbers behind it (tokens, cost,
  * per-agent accounting) live only in the run's state.json, so an event is a
- * signal to re-read rather than the data itself. Between events nothing is
- * read: the repaint timer only turns the spinner and advances the clocks.
+ * signal to re-read rather than the data itself. The repaint timer checks for
+ * changed state files without reparsing unchanged runs.
  */
 
 import { readFileSync, statSync } from "node:fs";
@@ -18,6 +19,7 @@ import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { AgentRecord, AgentState, RunRecord, RunState } from "pi-extensible-workflows";
+import { listRunIds, RunStore } from "pi-extensible-workflows/persistence";
 import {
   WORKFLOW_AGENT_STALL_THRESHOLD_MS,
   WORKFLOW_AGENT_STATE_CHANGED_EVENT,
@@ -28,6 +30,7 @@ import {
   WORKFLOW_RUN_FAILED_EVENT,
   WORKFLOW_RUN_STARTED_EVENT,
   WORKFLOW_RUN_STATE_CHANGED_EVENT,
+  object,
 } from "pi-extensible-workflows";
 
 const KEY = "piewf-widget";
@@ -159,17 +162,13 @@ type Paint = (role: Parameters<Theme["fg"]>[0], text: string) => string;
  * — the safe direction, since drawing a finished run costs a stale row while
  * missing a live one loses the display entirely.
  */
-const DONE_RUN = new Set<RunState>([
-  "completed",
-  "failed",
-  "stopped",
-  "interrupted",
-  "budget_exhausted",
-]);
+const TERMINAL_RUN = new Set<RunState>(["completed", "failed", "stopped"]);
 const DONE_AGENT = new Set<AgentState>(["completed", "failed", "cancelled"]);
 
+const isRunTerminal = (state: string | undefined): boolean =>
+  state !== undefined && TERMINAL_RUN.has(state as RunState);
 const isRunLive = (state: string | undefined): boolean =>
-  state !== undefined && !DONE_RUN.has(state as RunState);
+  state !== undefined && !isRunTerminal(state);
 const isAgentLive = (state: string | undefined): boolean =>
   state !== undefined && !DONE_AGENT.has(state as AgentState);
 
@@ -197,11 +196,15 @@ interface Run extends Partial<RunRecord> {
 }
 
 interface ReceiptAgent {
+  id?: string;
+  parentId?: string;
   name: string;
   state: string;
   model?: string;
   role?: string;
   requestedModel?: string;
+  tools?: readonly string[];
+  /** Accepted for rendering older receipt entries; new receipts persist granted tools. */
   toolCalls?: number;
   input: number;
   output: number;
@@ -231,8 +234,8 @@ function spinner(now: number): string {
 }
 
 /** Status mark for a finished-or-running unit of work. */
-function mark(state: string | undefined, now: number, paint: Paint): string {
-  if (isAgentLive(state) && isRunLive(state)) return paint(ROLE.live, spinner(now));
+function mark(state: string | undefined, now: number, paint: Paint, runState?: string): string {
+  if (state === "running" && (runState === undefined || runState === "running")) return paint(ROLE.live, spinner(now));
   if (state === "completed") return paint(ROLE.done, "✓");
   if (state === "failed" || state === "budget_exhausted") return paint(ROLE.failed, "✗");
   return paint(ROLE.quiet, "·");
@@ -284,6 +287,45 @@ function truncate(text: string, limit: number): string {
   return `${truncateToWidth(text, limit, "…")}${RESET}`;
 }
 
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function optionalNumber(value: unknown): boolean {
+  return value === undefined || finiteNumber(value);
+}
+
+function renderableAgent(value: unknown): boolean {
+  if (!object(value) || typeof value.name !== "string" || typeof value.state !== "string" || !object(value.model) || typeof value.model.model !== "string" || !Array.isArray(value.tools) || !value.tools.every((tool) => typeof tool === "string")) return false;
+  if (value.model.thinking !== undefined && typeof value.model.thinking !== "string") return false;
+  for (const key of ["id", "label", "parentId", "role", "requestedModel"] as const) if (value[key] !== undefined && typeof value[key] !== "string") return false;
+  for (const key of ["attempts", "startedAt", "durationMs", "lastEventAt"] as const) if (!optionalNumber(value[key])) return false;
+  const accounting = value.accounting;
+  if (accounting !== undefined && (!object(accounting) || !["input", "output", "cacheRead", "cacheWrite", "cost"].every((key) => optionalNumber(accounting[key])))) return false;
+  const attemptDetails = value.attemptDetails;
+  if (attemptDetails !== undefined && (!Array.isArray(attemptDetails) || attemptDetails.some((detail) => !object(detail)))) return false;
+  return true;
+}
+
+function renderableRun(value: unknown): value is Partial<RunRecord> {
+  if (!object(value) || typeof value.state !== "string") return false;
+  if (value.workflowName !== undefined && typeof value.workflowName !== "string") return false;
+  if (value.id !== undefined && typeof value.id !== "string") return false;
+  if (value.sessionId !== undefined && typeof value.sessionId !== "string") return false;
+  if (value.agents !== undefined && (!Array.isArray(value.agents) || value.agents.some((agent) => !renderableAgent(agent)))) return false;
+  const history = value.phaseHistory;
+  if (history !== undefined && (!Array.isArray(history) || history.some((entry) => !object(entry) || typeof entry.phase !== "string" || !finiteNumber(entry.afterAgent)))) return false;
+  const usage = value.usage;
+  if (usage !== undefined && (!object(usage) || !["tokens", "costUsd", "durationMs", "agentLaunches"].every((key) => optionalNumber(usage[key])))) return false;
+  const delivery = value.delivery;
+  if (delivery !== undefined && (!object(delivery) || typeof delivery.mode !== "string" || typeof delivery.state !== "string")) return false;
+  const budgetEvents = value.budgetEvents;
+  if (budgetEvents !== undefined && (!Array.isArray(budgetEvents) || budgetEvents.some((event) => !object(event) || typeof event.type !== "string" || !Array.isArray(event.dimensions) || !event.dimensions.every((dimension) => typeof dimension === "string")))) return false;
+  const shellActivity = value.activeShellsByPhase;
+  if (shellActivity !== undefined && (!Array.isArray(shellActivity) || shellActivity.some((entry) => !object(entry) || !finiteNumber(entry.phaseIndex) || !finiteNumber(entry.active) || !optionalNumber(entry.startedAt)))) return false;
+  return true;
+}
+
 /**
  * Reads one run's state.json.
  *
@@ -294,8 +336,10 @@ function truncate(text: string, limit: number): string {
  */
 function readRun(directory: string): Run | undefined {
   try {
-    const state = JSON.parse(readFileSync(join(directory, "state.json"), "utf8")) as Partial<RunRecord>;
-    return { ...state, directory, startedAt: statSync(directory).birthtimeMs };
+    const state: unknown = JSON.parse(readFileSync(join(directory, "state.json"), "utf8"));
+    if (!renderableRun(state)) return undefined;
+    const startedAt = statSync(directory).birthtimeMs;
+    return { ...state, directory, startedAt };
   } catch {
     // A run mid-write, or a directory without state yet.
     return undefined;
@@ -354,7 +398,7 @@ function lastTranscriptWrite(agent: AgentRecord, cache: Map<string, number | und
  * measured against the transcript, not the run state.
  */
 function agentSilentFor(agent: AgentRecord, now: number, cache: Map<string, number | undefined>): number | undefined {
-  if (!isAgentLive(agent.state)) return undefined;
+  if (agent.state !== "running") return undefined;
   const last = Math.max(agent.lastEventAt ?? 0, lastTranscriptWrite(agent, cache) ?? 0);
   if (last === 0) return undefined;
   const silent = now - last;
@@ -400,19 +444,28 @@ function budgetWarning(run: Run): string | undefined {
 function agentTokens(agent: AgentRecord): number {
   const accounting = agent.accounting;
   if (!accounting) return 0;
-  return accounting.input + accounting.output + accounting.cacheWrite;
+  return accounting.input + accounting.output;
 }
 
 /** Phase names in the order they opened, with the agents that ran in each. */
-function phaseSlices(run: Run): { phase: string; agents: readonly AgentRecord[] }[] {
+type PhaseSlice = { phase: string; agents: readonly AgentRecord[]; phaseIndex?: number };
+
+function phaseSlices(run: Run): PhaseSlice[] {
   const history = run.phaseHistory ?? [];
   const agents = run.agents ?? [];
-  return history.map((entry, index) => {
-    const from = entry.afterAgent;
+  if (history.length === 0) return agents.length === 0 ? [] : [{ phase: "unphased", agents }];
+
+  const bound = (value: number): number => Math.max(0, Math.min(value, agents.length));
+  const slices: PhaseSlice[] = [];
+  const first = bound(history[0]?.afterAgent ?? 0);
+  if (first > 0) slices.push({ phase: "unphased", agents: agents.slice(0, first) });
+  history.forEach((entry, index) => {
+    const from = bound(entry.afterAgent);
     const next = history[index + 1];
-    const to = next ? next.afterAgent : agents.length;
-    return { phase: entry.phase, agents: agents.slice(from, to) };
+    const to = next === undefined ? agents.length : bound(next.afterAgent);
+    slices.push({ phase: entry.phase, phaseIndex: index, agents: agents.slice(from, to) });
   });
+  return slices;
 }
 
 /**
@@ -460,8 +513,8 @@ interface Row {
 
 /**
  * Folds the least interesting rows away once the tree outgrows its budget,
- * leaving a marker in their place. Run headers always survive: losing one hides
- * a whole run rather than a detail of it.
+ * leaving a marker in their place. Run headers are prioritized so every visible
+ * run retains its title without exceeding the frame budget.
  */
 /**
  * The furthest the window may travel: the offset whose window ends on the last
@@ -473,6 +526,7 @@ interface Row {
  * offset nothing can see — paid back later as arrow presses that do nothing.
  */
 function maxOffset(total: number, budget: number): number {
+  if (total <= budget) return 0;
   return Math.max(0, total - (budget - 1));
 }
 
@@ -482,46 +536,39 @@ function collapse(rows: readonly Row[], budget: number, paint: Paint, offset: nu
   // Scrolling: a window onto the tree, with the count of what lies past the
   // bottom edge. Reading it is a matter of moving the window rather than
   // deciding for the reader which rows deserve the space.
-  //
-  // The window is used from the moment scrolling starts, offset zero included.
-  // Entering at the resting view instead would show a set of rows picked by
-  // rank — non-contiguous, with the gaps unmarked — and the first press would
-  // then jump to a different set entirely rather than moving by one row.
   if (scrolling) {
     const start = Math.min(offset, maxOffset(rows.length, budget));
     const window = rows.slice(start, start + budget - 1);
     const below = rows.length - start - window.length;
-    const out = [...window];
-    out.push({ rank: 0, text: paint(ROLE.quiet, below > 0 ? `… ${String(below)} more` : `… ${String(start)} above`) });
-    return out;
+    return [
+      ...window,
+      { rank: 0, text: paint(ROLE.quiet, below > 0 ? `… ${String(below)} more` : `… ${String(start)} above`) },
+    ];
   }
 
-  // At rest: keep the rows that say most, since nobody is steering. Run
-  // headers first, then live or failed work, then finished detail.
-  //
-  // Headers are taken before anything else at the same rank, and taken whole:
-  // a run whose header is dropped vanishes from the widget entirely, while a
-  // run that loses its detail rows is merely terse. Ranking alone would let
-  // one early run's checkpoints spend the budget and hide a later run.
+  // At rest: keep the rows that say most, since nobody is steering. Reserve
+  // one body row for the marker unless headers alone fill the budget.
   const keep = new Set<number>();
-  for (const [index, row] of rows.entries()) if (row.rank === 2 && row.header === true) keep.add(index);
+  const headerCount = rows.filter((row) => row.rank === 2 && row.header === true).length;
+  const reserveMarker = headerCount !== budget;
+  const capacity = reserveMarker ? Math.max(0, budget - 1) : budget;
+  for (const [index, row] of rows.entries()) {
+    if (row.rank === 2 && row.header === true && keep.size < capacity) keep.add(index);
+  }
   for (const rank of [2, 1, 0]) {
     for (const [index, row] of rows.entries()) {
-      if (row.rank === rank && keep.size < budget - 1) keep.add(index);
+      if (row.rank === rank && keep.size < capacity) keep.add(index);
     }
   }
 
   const out: Row[] = [];
   let hidden = 0;
   for (const [index, row] of rows.entries()) {
-    if (keep.has(index)) {
-      out.push(row);
-    } else {
-      hidden += 1;
-    }
+    if (keep.has(index)) out.push(row);
+    else hidden += 1;
   }
-  if (hidden > 0) out.push({ rank: 0, text: paint(ROLE.quiet, `… ${String(hidden)} more`) });
-  return out;
+  if (hidden > 0 && reserveMarker) out.push({ rank: 0, text: paint(ROLE.quiet, `… ${String(hidden)} more`) });
+  return out.slice(0, budget);
 }
 
 
@@ -557,7 +604,7 @@ function renderFrame(runs: readonly Run[], now: number, width: number, offset = 
       rank: 2,
       header: true,
       key: runKey,
-      text: `${mark(run.state, now, paint)} ${run.workflowName ?? "workflow"}${
+      text: `${mark(run.state, now, paint, run.state)} ${run.workflowName ?? "workflow"}${
         budget ? `  ${paint(ROLE.warn, budget)}` : ""
       }`,
       right: `${stats ? `${stats} · ` : ""}${formatElapsed(now - run.startedAt)}`,
@@ -581,7 +628,7 @@ function renderFrame(runs: readonly Run[], now: number, width: number, offset = 
         (agent) => isAgentLive(agent.state),
       );
       const failed = slice.agents.some((agent) => agent.state === "failed");
-      const phaseState = liveAgents ? "running" : failed ? "failed" : "completed";
+      const phaseState = failed ? "failed" : liveAgents && run.state === "running" ? "running" : run.state === "running" ? "completed" : run.state;
 
       let cost = 0;
       let tokens = 0;
@@ -596,7 +643,7 @@ function renderFrame(runs: readonly Run[], now: number, width: number, offset = 
         rank: liveAgents || failed ? 1 : 0,
         key: phaseKey,
         parent: runKey,
-        text: `  ${last ? "╰─" : "├─"} ${mark(phaseState, now, paint)} ${slice.phase}`,
+        text: `  ${last ? "╰─" : "├─"} ${mark(phaseState, now, paint, run.state)} ${slice.phase}`,
         ...(phaseStats ? { right: phaseStats } : {}),
       });
 
@@ -604,12 +651,12 @@ function renderFrame(runs: readonly Run[], now: number, width: number, offset = 
 
       // A phase running only shell commands has no agents under it, so without
       // this it reads as a name with nothing happening beneath it.
-      const shell = phaseShellRow(run, index, now);
+      const shell = slice.phaseIndex === undefined ? undefined : phaseShellRow(run, slice.phaseIndex, now);
       if (shell) {
         rows.push({
           rank: 1,
           parent: phaseKey,
-          text: `${stem} ${slice.agents.length === 0 ? "╰─" : "├─"} ${mark("running", now, paint)} ${shell.label}`,
+          text: `${stem} ${slice.agents.length === 0 ? "╰─" : "├─"} ${mark("running", now, paint, run.state)} ${shell.label}`,
           right: shell.elapsed,
         });
       }
@@ -657,7 +704,7 @@ function renderFrame(runs: readonly Run[], now: number, width: number, offset = 
           text: `${prefix}${lastAgent ? "╰─" : "├─"} ${
 
             silent === undefined
-              ? mark(agent.state, now, paint)
+              ? mark(agent.state, now, paint, run.state)
               : paint(silent >= STALL_MS ? ROLE.failed : ROLE.warn, "⚠")
           } ${
             // The label is what the workflow called this agent — `reviewer #2`,
@@ -772,36 +819,27 @@ function renderFrame(runs: readonly Run[], now: number, width: number, offset = 
 }
 
 /** Everything worth keeping about a run once it is over. */
-/**
- * How many tool calls an agent made, counted from its transcript.
- *
- * `toolCalls` on the agent record is empty on disk — it is filled in memory and
- * only persisted at moments that have usually passed by the time a run ends.
- * The transcript is the durable record: every turn is appended as it happens.
- */
-function countToolCalls(run: Run, index: number): number | undefined {
-  const session = (run.agentSessions ?? [])[index];
-  const locator = session?.locator as { sessionFile?: string } | undefined;
-  const file = locator?.sessionFile;
-  if (!file) return undefined;
-  try {
-    let calls = 0;
-    for (const line of readFileSync(file, "utf8").split("\n")) {
-      if (line === "") continue;
-      const entry = JSON.parse(line) as { type?: string; message?: { content?: readonly { type?: string }[] } };
-      if (entry.type !== "message") continue;
-      for (const part of entry.message?.content ?? []) if (part.type === "toolCall") calls += 1;
+function receiptError(run: Run, fallback: { message?: string } | undefined): string | undefined {
+  if (run.error?.message) return run.error.message;
+  if (run.state !== "failed") return undefined;
+  if (fallback?.message) return fallback.message;
+  for (const agent of run.agents ?? []) {
+    for (const detail of [...(agent.attemptDetails ?? [])].reverse()) {
+      if (detail.error?.message) return detail.error.message;
     }
-    return calls;
-  } catch {
-    // The transcript was cleaned up, or is mid-write. A missing count is
-    // better than a wrong one.
-    return undefined;
   }
+  return undefined;
 }
-
-function receiptFor(run: Run): Receipt {
-  const agents = run.agents ?? [];
+function receiptFor(run: Run, fallback?: { message?: string }): Receipt {
+  const slices = phaseSlices(run);
+  const agents = slices.flatMap((slice) => slice.agents);
+  let boundary = 0;
+  const phaseBoundaries = slices.map((slice) => {
+    const current = boundary;
+    boundary += slice.agents.length;
+    return current;
+  });
+  const error = receiptError(run, fallback);
   return {
     runId: run.id ?? "",
     workflow: run.workflowName ?? "workflow",
@@ -809,41 +847,35 @@ function receiptFor(run: Run): Receipt {
     costUsd: run.usage?.costUsd ?? 0,
     tokens: run.usage?.tokens ?? 0,
     durationMs: run.usage?.durationMs ?? 0,
-    phases: (run.phaseHistory ?? []).map((entry) => entry.phase),
-    // Agents carry no phase of their own; phaseHistory records how many had
-    // finished when each phase opened, so these offsets are what tie them.
-    phaseBoundaries: (run.phaseHistory ?? []).map((entry) => entry.afterAgent),
-    agents: agents.map((agent, index) => {
-      const calls = countToolCalls(run, index);
-      return {
-        // What the workflow called it, falling back to the role it was built
-        // from. Two agents of one role are otherwise indistinguishable.
-        name: agent.label ?? agent.name,
-        state: agent.state,
-        // Model and thinking level together: a role picks both, and the model
-        // name alone does not say whether it reasoned cheaply or deeply.
-        ...(agent.model.model
-          ? {
-              model: `${agent.model.model}${agent.model.thinking ? `:${agent.model.thinking}` : ""}`,
-            }
-          : {}),
-        ...(agent.role ? { role: agent.role } : {}),
-        ...(agent.requestedModel ? { requestedModel: agent.requestedModel } : {}),
-        // What the agent actually did, not what it was allowed to do. The
-        // permitted toolbox is a property of the role and says nothing about
-        // this particular run; the number of calls says how hard it worked.
-        ...(calls === undefined ? {} : { toolCalls: calls }),
-        // Cache reads dwarf real input and cost almost nothing, so the split is
-        // what explains a cheap run that looks enormous.
-        input: agent.accounting?.input ?? 0,
-        output: agent.accounting?.output ?? 0,
-        cacheRead: agent.accounting?.cacheRead ?? 0,
-        costUsd: agent.accounting?.cost ?? 0,
-        durationMs: agent.durationMs ?? 0,
-        attempts: agent.attempts,
-      };
-    }),
-    ...(run.error?.message ? { error: run.error.message } : {}),
+    phases: slices.map(({ phase }) => phase),
+    phaseBoundaries,
+    agents: agents.map((agent) => ({
+      id: agent.id,
+      ...(agent.parentId === undefined ? {} : { parentId: agent.parentId }),
+      // What the workflow called it, falling back to the role it was built
+      // from. Two agents of one role are otherwise indistinguishable.
+      name: agent.label ?? agent.name,
+      state: agent.state,
+      // Model and thinking level together: a role picks both, and the model
+      // name alone does not say whether it reasoned cheaply or deeply.
+      ...(agent.model.model
+        ? {
+            model: `${agent.model.model}${agent.model.thinking ? `:${agent.model.thinking}` : ""}`,
+          }
+        : {}),
+      ...(agent.role ? { role: agent.role } : {}),
+      ...(agent.requestedModel ? { requestedModel: agent.requestedModel } : {}),
+      tools: [...agent.tools],
+      // Cache reads dwarf real input and cost almost nothing, so the split is
+      // what explains a cheap run that looks enormous.
+      input: agent.accounting?.input ?? 0,
+      output: agent.accounting?.output ?? 0,
+      cacheRead: agent.accounting?.cacheRead ?? 0,
+      costUsd: agent.accounting?.cost ?? 0,
+      durationMs: agent.durationMs ?? 0,
+      attempts: agent.attempts,
+    })),
+    ...(error === undefined ? {} : { error }),
   };
 }
 
@@ -890,8 +922,18 @@ export function renderReceipt(data: Receipt, expanded: boolean, theme: Theme): s
     );
 
     const stem = last ? "  " : "│ ";
-    agents.forEach((agent, agentIndex) => {
-      const lastAgent = agentIndex === agents.length - 1;
+    const inPhase = new Set(agents.flatMap((agent) => agent.id === undefined ? [] : [agent.id]));
+    const children = new Map<string, ReceiptAgent[]>();
+    const roots: ReceiptAgent[] = [];
+    for (const agent of agents) {
+      if (agent.parentId !== undefined && inPhase.has(agent.parentId)) {
+        children.set(agent.parentId, [...(children.get(agent.parentId) ?? []), agent]);
+      } else {
+        roots.push(agent);
+      }
+    }
+
+    const drawAgent = (agent: ReceiptAgent, prefix: string, lastAgent: boolean): void => {
       const detail = [
         agent.model ?? "",
         formatCost(agent.costUsd),
@@ -904,18 +946,20 @@ export function renderReceipt(data: Receipt, expanded: boolean, theme: Theme): s
         .join(" · ");
 
       lines.push(
-        `${stem} ${lastAgent ? "╰─" : "├─"} ${glyph(agent.state)} ${agent.name} ${theme.fg("muted", detail)}`,
+        `${prefix}${lastAgent ? "╰─" : "├─"} ${glyph(agent.state)} ${agent.name} ${theme.fg("muted", detail)}`,
       );
 
-      const under = `${stem} ${lastAgent ? "  " : "│ "}   `;
+      const under = `${prefix}${lastAgent ? "  " : "│ "}   `;
       const meta = [
         agent.role ? `role ${agent.role}` : "",
         agent.requestedModel && agent.requestedModel !== agent.model
           ? `via ${agent.requestedModel}`
           : "",
-        agent.toolCalls === undefined
-          ? ""
-          : `${String(agent.toolCalls)} ${agent.toolCalls === 1 ? "call" : "calls"}`,
+        agent.tools?.length
+          ? agent.tools.join(" ")
+          : agent.toolCalls === undefined
+            ? ""
+            : `${String(agent.toolCalls)} ${agent.toolCalls === 1 ? "call" : "calls"}`,
       ].filter(Boolean);
       if (meta.length > 0) lines.push(theme.fg("muted", `${under}${meta.join(" · ")}`));
 
@@ -925,6 +969,15 @@ export function renderReceipt(data: Receipt, expanded: boolean, theme: Theme): s
         agent.cacheRead ? `cache ${formatTokens(agent.cacheRead)}` : "",
       ].filter(Boolean);
       if (split.length > 0) lines.push(theme.fg("muted", `${under}${split.join(" · ")}`));
+
+      const kids = agent.id === undefined ? [] : children.get(agent.id) ?? [];
+      kids.forEach((child, childIndex) => {
+        drawAgent(child, under, childIndex === kids.length - 1);
+      });
+    };
+
+    roots.forEach((agent, agentIndex) => {
+      drawAgent(agent, `${stem} `, agentIndex === roots.length - 1);
     });
   });
 
@@ -942,6 +995,7 @@ export default function widget(pi: ExtensionAPI): void {
   let timer: NodeJS.Timeout | undefined;
   /** True while a frame is on screen, so it is only cleared when there is one. */
   let showing = false;
+  let renderFailed = false;
 
   /**
    * Whether the widget holds the keyboard, and which row is under the cursor.
@@ -963,7 +1017,7 @@ export default function widget(pi: ExtensionAPI): void {
    * something else currently owns the keyboard.
    */
   let host: TuiHandle | undefined;
-
+  let inputUnsubscribe: (() => void) | undefined;
   /**
    * Whether some other component is holding the keyboard.
    *
@@ -999,13 +1053,69 @@ export default function widget(pi: ExtensionAPI): void {
   const seen = new Map<string, number>();
   /** Runs already written to the transcript, so each is recorded once. */
   const receipted = new Set<string>();
+  /** Terminal completed/failed state events wait for their dedicated event. */
+  const awaitingDedicatedReceipt = new Set<string>();
+  const failureEvents = new Map<string, { message: string }>();
+  let sessionGeneration = 0;
 
   const sessionId = (): string | undefined => context?.sessionManager.getSessionId();
+  const resetNavigation = (): void => {
+    focused = false;
+    offset = 0;
+    rowCount = 0;
+    size.rows = 0;
+    host = undefined;
+  };
+  const hide = (): void => {
+    if (showing) {
+      try { context?.ui.setWidget(KEY, undefined); } catch { /* A failed repaint is already being cleared. */ }
+    }
+    showing = false;
+    renderFailed = false;
+    inputUnsubscribe?.();
+    inputUnsubscribe = undefined;
+    resetNavigation();
+  };
+  const handleInput = (data: string): { consume?: boolean } | undefined => {
+    if (!showing || !focused) return undefined;
+    if (somethingElseHasTheKeyboard()) {
+      focused = false;
+      offset = 0;
+      return undefined;
+    }
+    if (maxOffset(rowCount, MAX_ROWS - 2) === 0) {
+      focused = false;
+      offset = 0;
+      return undefined;
+    }
+    if (isKeyRelease(data)) return { consume: true };
+    if (matchesKey(data, Key.up)) {
+      offset = Math.max(0, offset - 1);
+      return { consume: true };
+    }
+    if (matchesKey(data, Key.down)) {
+      offset = Math.min(maxOffset(rowCount, MAX_ROWS - 2), offset + 1);
+      return { consume: true };
+    }
+    if (matchesKey(data, Key.escape) || data === "q") {
+      focused = false;
+      offset = 0;
+      return { consume: true };
+    }
+    focused = false;
+    offset = 0;
+    return undefined;
+  };
+  const installInput = (): void => {
+    if (!showing || !__navigationForTests.enabled || inputUnsubscribe || !context?.hasUI) return;
+    inputUnsubscribe = context.ui.onTerminalInput(handleInput);
+  };
+
 
   /** Re-read one run's state. Called on events, never on the repaint timer. */
   const refresh = (runId: string, directory: string, runSessionId: string): void => {
     // A run filed under another session belongs to another window's widget.
-    if (runSessionId !== sessionId()) return;
+    if (runSessionId !== sessionId() || receipted.has(runId)) return;
     const run = readRun(directory);
     if (!run) return;
     // A pending checkpoint is known only from events, so it has to survive a
@@ -1016,24 +1126,37 @@ export default function widget(pi: ExtensionAPI): void {
 
   const receipt = (runId: string): void => {
     if (receipted.has(runId)) return;
-    const run = runs.get(runId);
-    if (!run) return;
+    const current = runs.get(runId);
+    if (!current) return;
+    // Events are signals, not the receipt's data. Read the final atomic state
+    // again so a completion event cannot capture the preceding running state.
+    const persisted = readRun(current.directory);
+    if (!persisted || !isRunTerminal(persisted.state)) return;
+    const run = current.waiting ? { ...persisted, waiting: current.waiting } : persisted;
     receipted.add(runId);
     runs.delete(runId);
+    seen.delete(runId);
+    const failure = failureEvents.get(runId);
+    failureEvents.delete(runId);
     // A foreground run already left its own summary in the transcript, put
     // there by the workflow tool call that waited for it. A second account of
     // the same run directly beneath the first is noise.
     if (run.delivery?.mode === "foreground") return;
-    pi.appendEntry<Receipt>(ENTRY_TYPE, receiptFor(run));
+    pi.appendEntry<Receipt>(ENTRY_TYPE, receiptFor(run, failure));
   };
 
+
   const paint = (): void => {
-    if (!context?.hasUI) return;
-    if (!renderFrame([...runs.values()], Date.now(), 80)) {
-      if (showing) {
-        context.ui.setWidget(KEY, undefined);
-        showing = false;
-      }
+    if (!context?.hasUI) {
+      hide();
+      return;
+    }
+    if (renderFailed) {
+      hide();
+      return;
+    }
+    if (![...runs.values()].some((run) => isRunLive(run.state) && run.delivery?.mode !== "foreground")) {
+      hide();
       return;
     }
 
@@ -1043,6 +1166,10 @@ export default function widget(pi: ExtensionAPI): void {
     // and checked against another, and Pi treats an over-wide line as fatal
     // rather than wrapping it. Every row is clamped again on the way out, so
     // the worst case is a clipped row instead of a crashed session.
+    // Below the editor, where a running job belongs: it is something to
+    // glance down at, not something standing between the conversation and
+    // the place you type.
+    showing = true;
     context.ui.setWidget(
       KEY,
       (tui: TuiHandle, theme: Theme) => {
@@ -1050,31 +1177,44 @@ export default function widget(pi: ExtensionAPI): void {
         host = tui;
         return {
           render: (width: number): string[] => {
-            // The layout is composed against a floor of twenty columns, because
-            // a tree drawn narrower than that is unreadable anyway — but what
-            // leaves this function is measured against the width Pi actually
-            // gave. A pane narrower than the floor gets a cut frame; it does
-            // not get a crash, and pi-tui treats an over-wide line as fatal.
-            const usable = Math.max(20, width);
-            const frame = renderFrame([...runs.values()], Date.now(), usable, focused ? offset : 0, theme, focused, size) ?? [];
-            // The keys track the body rows exactly, so they say how far the
-            // cursor may travel — the lid and the floor are not rows to land on.
-            rowCount = size.rows;
-            return frame.map((line) =>
-              visibleLength(line) > width ? truncate(line, width) : line,
-            );
+            try {
+              // The layout is composed against a floor of twenty columns, because
+              // a tree drawn narrower than that is unreadable anyway — but what
+              // leaves this function is measured against the width Pi actually
+              // gave. A pane narrower than the floor gets a cut frame; it does
+              // not get a crash, and pi-tui treats an over-wide line as fatal.
+              const usable = Math.max(20, width);
+              const frame = renderFrame([...runs.values()], Date.now(), usable, focused ? offset : 0, theme, focused, size);
+              if (frame === undefined) {
+                renderFailed = true;
+                inputUnsubscribe?.();
+                inputUnsubscribe = undefined;
+                resetNavigation();
+                return [];
+              }
+              // The keys track the body rows exactly, so they say how far the
+              // cursor may travel — the lid and the floor are not rows to land on.
+              rowCount = size.rows;
+              offset = Math.min(offset, maxOffset(rowCount, MAX_ROWS - 2));
+              return frame.map((line) =>
+                visibleLength(line) > width ? truncate(line, width) : line,
+              );
+            } catch {
+              renderFailed = true;
+              inputUnsubscribe?.();
+              inputUnsubscribe = undefined;
+              resetNavigation();
+              return [];
+            }
           },
           invalidate: (): void => {
             // Nothing is cached between frames; every render reads current state.
           },
         };
       },
-      // Below the editor, where a running job belongs: it is something to
-      // glance down at, not something standing between the conversation and
-      // the place you type.
       { placement: "belowEditor" },
     );
-    showing = true;
+    installInput();
   };
 
   /**
@@ -1088,28 +1228,36 @@ export default function widget(pi: ExtensionAPI): void {
    */
   const rescan = (): void => {
     for (const [runId, run] of runs) {
+      if (receipted.has(runId)) {
+        runs.delete(runId);
+        seen.delete(runId);
+        continue;
+      }
       try {
         const mtime = statSync(join(run.directory, "state.json")).mtimeMs;
         if (mtime === seen.get(runId)) continue;
         seen.set(runId, mtime);
         const fresh = readRun(run.directory);
-        if (fresh) runs.set(runId, run.waiting ? { ...fresh, waiting: run.waiting } : fresh);
+        if (fresh) {
+          runs.set(runId, run.waiting ? { ...fresh, waiting: run.waiting } : fresh);
+          if (isRunTerminal(fresh.state) && !awaitingDedicatedReceipt.has(runId)) receipt(runId);
+        }
       } catch {
         // The run's directory went away, or is mid-write. Keep what we have.
       }
     }
   };
 
-  const tick = (): void => {
+  function tick(): void {
     try {
       rescan();
       paint();
     } catch {
       // A failed repaint is a skipped frame, never fatal: a widget that dies
       // quietly is indistinguishable from one that was never drawn.
-      showing = false;
+      hide();
     }
-  };
+  }
 
   // The transcript entry: appendEntry carries the data, this renders it. It
   // returns a plain component rather than importing pi-tui's Text, because
@@ -1128,21 +1276,20 @@ export default function widget(pi: ExtensionAPI): void {
     };
   });
 
-  const onRunEvent = (event: unknown): void => {
-    const { runId, runDirectory, sessionId: eventSession } = event as {
+  const onRunEvent = (event: unknown, terminal = false, deferReceipt = false): void => {
+    const { runId, runDirectory, sessionId: eventSession, error } = event as {
       runId?: string;
       runDirectory?: string;
       sessionId?: string;
+      error?: { message?: unknown };
     };
-    if (!runId || !runDirectory || !eventSession) return;
+    if (!runId || !runDirectory || !eventSession || eventSession !== sessionId()) return;
+    if (receipted.has(runId)) return;
+    if (deferReceipt) awaitingDedicatedReceipt.add(runId);
+    if (terminal) awaitingDedicatedReceipt.delete(runId);
+    if (typeof error?.message === "string") failureEvents.set(runId, { message: error.message });
     refresh(runId, runDirectory, eventSession);
-    // A run can end without a completed or failed event: stopping it, running
-    // it out of budget or losing it to an interrupt all arrive as a state
-    // change. Reading the state rather than the event name means every ending
-    // leaves a receipt — and an interrupted run is exactly the one whose cost
-    // is worth having a record of.
-    const run = runs.get(runId);
-    if (run && !isRunLive(run.state)) receipt(runId);
+    if (terminal) receipt(runId);
     tick();
   };
 
@@ -1151,7 +1298,6 @@ export default function widget(pi: ExtensionAPI): void {
 
   for (const name of [
     WORKFLOW_RUN_STARTED_EVENT,
-    WORKFLOW_RUN_STATE_CHANGED_EVENT,
     WORKFLOW_AGENT_STATE_CHANGED_EVENT,
     WORKFLOW_PHASE_CHANGED_EVENT,
     WORKFLOW_BUDGET_EVENT,
@@ -1159,14 +1305,26 @@ export default function widget(pi: ExtensionAPI): void {
     unsubscribes.push(pi.events.on(name, onRunEvent));
   }
 
+  unsubscribes.push(pi.events.on(WORKFLOW_RUN_STATE_CHANGED_EVENT, (event: unknown) => {
+    const state = (event as { state?: unknown }).state;
+    onRunEvent(event, state === "stopped", state === "completed" || state === "failed");
+  }));
+  for (const name of [WORKFLOW_RUN_COMPLETED_EVENT, WORKFLOW_RUN_FAILED_EVENT]) {
+    unsubscribes.push(pi.events.on(name, (event: unknown) => {
+      onRunEvent(event, true);
+    }));
+  }
   unsubscribes.push(
     pi.events.on(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, (event: unknown) => {
-      const { runId, name, state } = event as {
+      const { runId, runDirectory, sessionId: eventSession, name, state } = event as {
         runId?: string;
+        runDirectory?: string;
+        sessionId?: string;
         name?: string;
         state?: string;
       };
-      if (!runId) return;
+      if (!runId || !runDirectory || !eventSession || eventSession !== sessionId()) return;
+      refresh(runId, runDirectory, eventSession);
       const run = runs.get(runId);
       if (!run) return;
       if (state === "awaiting") {
@@ -1182,47 +1340,51 @@ export default function widget(pi: ExtensionAPI): void {
     }),
   );
 
-  for (const name of [WORKFLOW_RUN_COMPLETED_EVENT, WORKFLOW_RUN_FAILED_EVENT]) {
-    unsubscribes.push(
-      pi.events.on(name, (event: unknown) => {
-        const { runId } = event as { runId?: string };
-        onRunEvent(event);
-        // The terminal state lands in state.json just after the event, so the
-        // receipt is taken on the next tick rather than this one.
-        if (runId) setTimeout(() => { receipt(runId); tick(); }, 100).unref();
-      }),
-    );
-  }
 
   const stop = (): void => {
+    sessionGeneration += 1;
     if (timer) clearInterval(timer);
     timer = undefined;
-    if (showing) context?.ui.setWidget(KEY, undefined);
-    showing = false;
-    focused = false;
+    failureEvents.clear();
+    hide();
+    runs.clear();
+    seen.clear();
+    receipted.clear();
+    awaitingDedicatedReceipt.clear();
     for (const unsubscribe of unsubscribes.splice(0)) unsubscribe();
   };
 
+  const reconcile = async (sessionContext: ExtensionContext, generation: number): Promise<void> => {
+    if (typeof sessionContext.cwd !== "string" || !sessionContext.cwd) {
+      if (generation === sessionGeneration) tick();
+      return;
+    }
+    const currentSessionId = sessionContext.sessionManager.getSessionId();
+    const runIds = await listRunIds(sessionContext.cwd, currentSessionId);
+    if (generation !== sessionGeneration || context !== sessionContext) return;
+    for (const runId of runIds) {
+      if (generation !== sessionGeneration || context !== sessionContext) return;
+      if (receipted.has(runId)) continue;
+      const directory = new RunStore(sessionContext.cwd, currentSessionId, runId).directory;
+      const run = readRun(directory);
+      if (!run || run.sessionId !== currentSessionId || run.delivery?.mode === "foreground") continue;
+      const waiting = runs.get(runId)?.waiting;
+      runs.set(runId, waiting ? { ...run, waiting } : run);
+      try { seen.set(runId, statSync(join(directory, "state.json")).mtimeMs); } catch { /* Retry on the next event if the state is mid-write. */ }
+      if (isRunTerminal(run.state) && !awaitingDedicatedReceipt.has(runId)) receipt(runId);
+    }
+    if (generation === sessionGeneration) tick();
+  };
 
   pi.on("session_start", (_event, sessionContext) => {
     context = sessionContext;
-    // The core drops every extension widget when a session starts or reloads,
-    // so nothing of this instance is on screen at this point.
-    showing = false;
-
-    // Replay what the session already recorded so a reload cannot write the
-    // same run into the transcript twice.
-    //
-    // The caches go with it. A reload may be entering a different session
-    // entirely, and runs left over from the last one would be drawn as though
-    // they were this session's; `seen` holds modification times that no longer
-    // describe anything, so a run whose file changed while the session was
-    // away would be judged unchanged and never re-read.
+    const generation = ++sessionGeneration;
+    hide();
+    failureEvents.clear();
     runs.clear();
     seen.clear();
-    focused = false;
-    offset = 0;
     receipted.clear();
+    awaitingDedicatedReceipt.clear();
     try {
       for (const entry of sessionContext.sessionManager.getEntries()) {
         const custom = entry as { type?: string; customType?: string; data?: { runId?: string } };
@@ -1235,60 +1397,13 @@ export default function widget(pi: ExtensionAPI): void {
 
     if (!timer) {
       timer = setInterval(tick, REPAINT_MS);
-      // Never hold the process open for the sake of a status line.
       timer.unref();
     }
 
-    // Keyboard access, taken as lightly as possible.
-    //
-    // The handler sees every keystroke before the editor does, so it declines
-    // all but a few, and only while scrolling. `↓` on an empty editor would be
-    // the comfortable way in, but an empty editor is what every picker and
-    // dialog leaves behind while it waits for arrows — so the way in is the
-    // shortcut alone, which never has to share.
-    if (__navigationForTests.enabled) {
-      unsubscribes.push(
-        sessionContext.ui.onTerminalInput((data: string) => {
-          if (!showing) return undefined;
-
-          if (focused) {
-          // Something opened over the widget while it held the keyboard — a
-          // command picker, a dialog. It has the better claim.
-          if (somethingElseHasTheKeyboard()) {
-            focused = false;
-            return undefined;
-          }
-          // The tail of a keystroke already acted on. Swallow it so it cannot
-          // reach the editor, but do not move twice for one press.
-          if (isKeyRelease(data)) return { consume: true };
-          if (matchesKey(data, Key.up)) {
-            offset = Math.max(0, offset - 1);
-            return { consume: true };
-          }
-          if (matchesKey(data, Key.down)) {
-            // Stops where the window stops. Counting rows instead would let
-            // presses past the last row bank an offset nothing on screen can
-            // show, and every one of them would have to be paid back with an
-            // ↑ that appears to do nothing.
-            offset = Math.min(maxOffset(rowCount, MAX_ROWS - 2), offset + 1);
-            return { consume: true };
-          }
-          if (matchesKey(data, Key.escape) || data === "q") {
-              focused = false;
-              return { consume: true };
-            }
-            // Anything else is someone typing: hand the keyboard back and let
-            // the keystroke through, so a thought is never lost to a panel.
-            focused = false;
-            return undefined;
-          }
-
-          return undefined;
-        }),
-      );
-    }
-
     tick();
+    void reconcile(sessionContext, generation).catch(() => {
+      if (generation === sessionGeneration) tick();
+    });
   });
 
   // A way in that never competes. `↓` is the comfortable gesture but it is
@@ -1297,7 +1412,11 @@ export default function widget(pi: ExtensionAPI): void {
   if (__navigationForTests.enabled) pi.registerShortcut(FOCUS_SHORTCUT, {
     description: "Scroll the workflow widget",
     handler: () => {
-      if (!showing) return;
+      if (!showing || maxOffset(rowCount, MAX_ROWS - 2) === 0) {
+        focused = false;
+        offset = 0;
+        return;
+      }
       focused = !focused;
       offset = 0;
     },

--- a/packages/extensions/widget/index.ts
+++ b/packages/extensions/widget/index.ts
@@ -1,0 +1,1101 @@
+/**
+ * Live workflow widget: a tree of the runs happening right now, drawn above the
+ * editor, and a durable receipt in the transcript once each one finishes.
+ *
+ * The split is deliberate. The widget answers "what is happening" and holds
+ * nothing that has already happened — a finished run disappears from it at
+ * once. The transcript entry answers "what did that cost and who did it", and
+ * keeps the answer for the life of the session rather than for a minute.
+ *
+ * Run state arrives as workflow events; the numbers behind it (tokens, cost,
+ * per-agent accounting) live only in the run's state.json, so an event is a
+ * signal to re-read rather than the data itself. Between events nothing is
+ * read: the repaint timer only turns the spinner and advances the clocks.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { isKeyRelease, Key, matchesKey } from "@earendil-works/pi-tui";
+import type { AgentRecord, AgentState, RunRecord, RunState } from "pi-extensible-workflows";
+import {
+  WORKFLOW_AGENT_STALL_THRESHOLD_MS,
+  WORKFLOW_AGENT_STATE_CHANGED_EVENT,
+  WORKFLOW_BUDGET_EVENT,
+  WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT,
+  WORKFLOW_PHASE_CHANGED_EVENT,
+  WORKFLOW_RUN_COMPLETED_EVENT,
+  WORKFLOW_RUN_FAILED_EVENT,
+  WORKFLOW_RUN_STARTED_EVENT,
+  WORKFLOW_RUN_STATE_CHANGED_EVENT,
+} from "pi-extensible-workflows";
+
+const KEY = "piewf-widget";
+const ENTRY_TYPE = "piewf-run-receipt";
+
+/**
+ * Repaint interval. Fast enough that the spinner reads as motion rather than a
+ * stutter; the underlying data is only re-read when an event says it changed.
+ */
+const REPAINT_MS = 125;
+
+/**
+ * Rows the whole frame may occupy, border included.
+ *
+ * Pi's ten-line widget cap applies to string arrays, not to a rendered
+ * component, so this is a choice about how much screen a status line deserves
+ * rather than a limit imposed from outside. What does not fit is folded away by
+ * rank, so live work survives and finished work is dropped first.
+ */
+const MAX_ROWS = 20;
+
+/**
+ * Key matching belongs to Pi, not here.
+ *
+ * A terminal has several ways to spell an arrow — the bare `\x1b[B`, the kitty
+ * protocol's parameterised form with press/release/repeat, xterm's
+ * modifyOtherKeys — and which one arrives depends on the terminal and on what
+ * Pi negotiated with it. `matchesKey` already knows them all, including the
+ * per-terminal quirks; a hand-rolled comparison would be a worse copy that
+ * silently matches nothing the day a terminal changes its mind.
+ */
+
+/**
+ * How long an agent may go without an event before the widget says so. Taken
+ * from the core so the widget and the runtime agree on what "stuck" means.
+ */
+/**
+ * How long an agent may go without an event before the widget says so.
+ *
+ * Deliberately shorter than the core's own stall threshold. That one answers
+ * "is this agent dead"; this one answers "should you go and look". An agent
+ * asking a question in its own pane produces exactly this signature — no tool
+ * calls, no events, waiting on a person — and the core cannot see it, since the
+ * pane is a separate process. Three minutes is longer than any single stretch
+ * of thinking and far shorter than the ten minutes it takes to be declared
+ * stalled.
+ */
+const QUIET_MS = 3 * 60 * 1000;
+
+/** The core's own threshold for calling an agent stalled outright. */
+const STALL_MS = WORKFLOW_AGENT_STALL_THRESHOLD_MS;
+
+/**
+ * How long a phase's shell commands must run before they are worth a row. A
+ * phase built entirely of short commands would otherwise flicker a line in and
+ * out; one that sits on a build or a test suite is exactly what you want to see.
+ */
+const SHELL_VISIBLE_MS = 5000;
+
+/**
+ * The shortcut that focuses the widget.
+ *
+ * `↓` from an empty editor is the comfortable way in, but an empty editor is
+ * also what every picker and dialog leaves behind while it waits for arrows, so
+ * that gesture has to defer to whatever else is on screen. This one never has
+ * to — and being registered through Pi, it can be rebound in `keybindings.json`
+ * like any other shortcut.
+ */
+const FOCUS_SHORTCUT = "alt+o";
+
+const BLUE = "\x1b[38;2;77;163;255m";
+const RED = "\x1b[38;2;235;87;87m";
+const GREEN = "\x1b[38;2;95;186;125m";
+const AMBER = "\x1b[38;2;222;158;65m";
+const DIM = "\x1b[38;2;120;120;120m";
+const RESET = "\x1b[0m";
+
+/**
+ * States that mean work is still happening, derived from the core's own lists
+ * rather than restated here: a state the widget does not recognise reads as
+ * finished, and the whole frame vanishes mid-run. Naming what is *over* rather
+ * than what is live means a state added upstream is treated as live by default
+ * — the safe direction, since drawing a finished run costs a stale row while
+ * missing a live one loses the display entirely.
+ */
+const DONE_RUN = new Set<RunState>([
+  "completed",
+  "failed",
+  "stopped",
+  "interrupted",
+  "budget_exhausted",
+]);
+const DONE_AGENT = new Set<AgentState>(["completed", "failed", "cancelled"]);
+
+const isRunLive = (state: string | undefined): boolean =>
+  state !== undefined && !DONE_RUN.has(state as RunState);
+const isAgentLive = (state: string | undefined): boolean =>
+  state !== undefined && !DONE_AGENT.has(state as AgentState);
+
+/**
+ * Braille wheel, one glyph per repaint.
+ *
+ * No repeated glyph at the ends: with the first and last the same, the wheel
+ * stalls for a frame on every turn and reads as a stutter.
+ */
+const SPINNER = ["⣷", "⣯", "⣟", "⡿", "⢿", "⣽", "⣻"] as const;
+
+/**
+ * A run as the widget sees it: the core's own record, plus where it was read
+ * from and when it started.
+ *
+ * The shape is imported rather than restated. Restating it means the widget's
+ * idea of a run silently drifts from the runtime's — which is exactly how a
+ * live state ends up unrecognised and the whole frame disappears.
+ */
+interface Run extends Partial<RunRecord> {
+  directory: string;
+  startedAt: number;
+  /** A checkpoint waiting for an answer, learned from events rather than disk. */
+  waiting?: { name: string; since: number };
+}
+
+interface ReceiptAgent {
+  name: string;
+  state: string;
+  model?: string;
+  role?: string;
+  requestedModel?: string;
+  toolCalls?: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  costUsd: number;
+  durationMs: number;
+  attempts: number;
+}
+
+interface Receipt {
+  runId: string;
+  workflow: string;
+  state: string;
+  costUsd: number;
+  tokens: number;
+  durationMs: number;
+  phases: readonly string[];
+  phaseBoundaries: readonly number[];
+  agents: readonly ReceiptAgent[];
+  error?: string;
+}
+
+function spinner(now: number): string {
+  // Tied to the repaint interval rather than a period of its own: a wheel that
+  // advances faster than the screen redraws skips glyphs and reads as jitter.
+  return SPINNER[Math.floor(now / REPAINT_MS) % SPINNER.length] ?? SPINNER[0];
+}
+
+/** Status mark for a finished-or-running unit of work. */
+function mark(state: string | undefined, now: number): string {
+  if (isAgentLive(state) && isRunLive(state)) return `${BLUE}${spinner(now)}${RESET}`;
+  if (state === "completed") return `${GREEN}✓${RESET}`;
+  if (state === "failed" || state === "budget_exhausted") return `${RED}✗${RESET}`;
+  return `${DIM}·${RESET}`;
+}
+
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+function formatTokens(tokens: number | undefined): string {
+  if (!tokens) return "";
+  if (tokens < 1000) return `${String(tokens)}t`;
+  const thousands = tokens / 1000;
+  return `${thousands < 10 ? thousands.toFixed(1) : String(Math.round(thousands))}kt`;
+}
+
+function formatCost(cost: number | undefined): string {
+  if (!cost) return "";
+  // Three decimals below a cent: at two, every cheap agent reads as $0.00 and
+  // the per-agent column becomes a row of zeroes.
+  return cost < 0.01 ? `$${cost.toFixed(3)}` : `$${cost.toFixed(2)}`;
+}
+
+/** Visible width, ignoring ANSI colour codes, so the border lines up. */
+function visibleLength(text: string): number {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*m/g, "").length;
+}
+
+/**
+ * Cuts a coloured line down to a visible width.
+ *
+ * Walks the string rather than slicing it: an escape sequence costs no columns
+ * but plenty of characters, so a plain slice either cuts mid-escape — bleeding
+ * colour into the border — or stops far short of the width it was given.
+ */
+function truncate(text: string, limit: number): string {
+  let out = "";
+  let visible = 0;
+  let index = 0;
+  while (index < text.length) {
+    // eslint-disable-next-line no-control-regex
+    const escape = /^\x1b\[[0-9;]*m/.exec(text.slice(index));
+    if (escape?.[0]) {
+      out += escape[0];
+      index += escape[0].length;
+      continue;
+    }
+    if (visible >= limit - 1) break;
+    const character = text[index];
+    if (character === undefined) break;
+    out += character;
+    visible += 1;
+    index += 1;
+  }
+  return `${out}…${RESET}`;
+}
+
+/**
+ * Reads one run's state.json.
+ *
+ * The run carries no start time of its own and state.json is rewritten whole on
+ * every step, so its birth time keeps moving. The directory is created once and
+ * never touched again — that is the start. Taking it from the file made the
+ * clock restart on every phase.
+ */
+function readRun(directory: string): Run | undefined {
+  try {
+    const state = JSON.parse(readFileSync(join(directory, "state.json"), "utf8")) as Partial<RunRecord>;
+    return { ...state, directory, startedAt: statSync(directory).birthtimeMs };
+  } catch {
+    // A run mid-write, or a directory without state yet.
+    return undefined;
+  }
+}
+
+/**
+ * When this run's agent sessions last grew, by the transcript files themselves.
+ *
+ * The run state's own `lastEventAt` is not a sign of life: the core keeps it in
+ * memory and only writes it out when it persists, so a perfectly busy agent
+ * looks silent for minutes at a time. The agent's transcript, on the other
+ * hand, is appended to on every turn — if that file is growing, work is
+ * happening, whatever the run state says.
+ */
+function lastTranscriptWrite(run: Run): number | undefined {
+  let newest: number | undefined;
+  for (const session of run.agentSessions ?? []) {
+    const locator = session.locator as { sessionFile?: string } | undefined;
+    const file = locator?.sessionFile;
+    if (!file) continue;
+    try {
+      const { mtimeMs } = statSync(file);
+      if (newest === undefined || mtimeMs > newest) newest = mtimeMs;
+    } catch {
+      // The transcript moved or was cleaned up; other sessions may still answer.
+    }
+  }
+  return newest;
+}
+
+/**
+ * How long an agent has been silent, once that crosses the quiet threshold.
+ *
+ * An agent thinking hard looks exactly like an agent whose transport died: both
+ * are a spinner that does not stop. Silence separates them — but it has to be
+ * measured against the transcript, not the run state.
+ */
+function agentSilentFor(agent: AgentRecord, run: Run, now: number): number | undefined {
+  if (!isAgentLive(agent.state)) return undefined;
+  const last = Math.max(agent.lastEventAt ?? 0, lastTranscriptWrite(run) ?? 0);
+  if (last === 0) return undefined;
+  const silent = now - last;
+  return silent >= QUIET_MS ? silent : undefined;
+}
+
+/**
+ * Shell activity for one phase, when it has been running long enough to matter.
+ *
+ * A phase of pure shell work has no agents, so without this it draws as a bare
+ * name with nothing under it and reads as stalled.
+ */
+function phaseShellRow(run: Run, phaseIndex: number, now: number): string | undefined {
+  const entry = run.activeShellsByPhase?.find((item) => item.phaseIndex === phaseIndex);
+  const active = entry?.active ?? 0;
+  if (active <= 0) return undefined;
+  const startedAt = entry?.startedAt;
+  if (startedAt === undefined || now - startedAt < SHELL_VISIBLE_MS) return undefined;
+  const label = active === 1 ? "1 command" : `${String(active)} commands`;
+  return `${label}${DIM} · ${formatElapsed(now - startedAt)}${RESET}`;
+}
+
+/** The worst budget threshold a run has crossed, and on which dimensions. */
+function budgetWarning(run: Run): string | undefined {
+  const events = run.budgetEvents ?? [];
+  if (events.length === 0) return undefined;
+  const worst = ["hard_exhausted", "hard_overrun", "soft_crossed"].find((type) =>
+    events.some((event) => event.type === type),
+  );
+  if (!worst) return undefined;
+  const dimensions = [
+    ...new Set(
+      events.filter((event) => event.type === worst).flatMap((event) => event.dimensions),
+    ),
+  ];
+  const what = dimensions.length > 0 ? ` (${dimensions.join(", ")})` : "";
+  if (worst === "soft_crossed") return `near budget${what}`;
+  return worst === "hard_overrun" ? `over budget${what}` : `budget exhausted${what}`;
+}
+
+function agentTokens(agent: AgentRecord): number {
+  const accounting = agent.accounting;
+  if (!accounting) return 0;
+  return accounting.input + accounting.output + accounting.cacheWrite;
+}
+
+/** Phase names in the order they opened, with the agents that ran in each. */
+function phaseSlices(run: Run): { phase: string; agents: readonly AgentRecord[] }[] {
+  const history = run.phaseHistory ?? [];
+  const agents = run.agents ?? [];
+  return history.map((entry, index) => {
+    const from = entry.afterAgent;
+    const next = history[index + 1];
+    const to = next ? next.afterAgent : agents.length;
+    return { phase: entry.phase, agents: agents.slice(from, to) };
+  });
+}
+
+/**
+ * The slice of Pi's TUI this widget needs: who holds the keyboard.
+ *
+ * Declared structurally rather than imported, so an older host missing either
+ * accessor degrades to "nothing else is focused" instead of failing to load.
+ */
+interface TuiHandle {
+  hasOverlay?: () => boolean;
+  getFocusedComponent?: () => unknown;
+}
+
+interface Row {
+  text: string;
+  /**
+   * Numbers to set against the right-hand rule rather than trailing the name.
+   *
+   * Names are ragged — a phase called `plan` beside one called `refactor-2` —
+   * so numbers that follow them are ragged too, and comparing the cost of one
+   * agent against another means reading across a gap that moves on every row.
+   * Held to the right edge, they form a column.
+   */
+  right?: string;
+  /** 2 = run header (never folded), 1 = live or failed, 0 = finished detail. */
+  rank: number;
+}
+
+/**
+ * Folds the least interesting rows away once the tree outgrows its budget,
+ * leaving a marker in their place. Run headers always survive: losing one hides
+ * a whole run rather than a detail of it.
+ */
+function collapse(rows: readonly Row[], budget: number): Row[] {
+  if (rows.length <= budget) return [...rows];
+
+  const keep = new Set<number>();
+  for (const rank of [2, 1, 0]) {
+    for (const [index, row] of rows.entries()) {
+      if (row.rank === rank && keep.size < budget - 1) keep.add(index);
+    }
+  }
+
+  const out: Row[] = [];
+  let hidden = 0;
+  for (const [index, row] of rows.entries()) {
+    if (keep.has(index)) {
+      out.push(row);
+    } else {
+      hidden += 1;
+    }
+  }
+  if (hidden > 0) out.push({ rank: 0, text: `${DIM}… ${String(hidden)} more${RESET}` });
+  return out;
+}
+
+/** The whole widget frame, or undefined when nothing is running. */
+function renderFrame(runs: readonly Run[], now: number, width: number, cursor?: number, theme?: Theme): string[] | undefined {
+  // Only live background runs.
+  //
+  // A finished run leaves its own receipt in the transcript, so holding it
+  // above the editor afterwards says the same thing twice — and the transcript
+  // keeps it for good, where the widget only kept it for a minute.
+  //
+  // A foreground run is already drawn by the workflow tool's own output, in
+  // more detail than this can offer: it has the live activity and token counts
+  // that never reach the run state on disk. Drawing it here too would be two
+  // views of one run disagreeing with each other. Background runs have no such
+  // view — the tool call returned the moment they started.
+  const live = runs.filter((run) => isRunLive(run.state) && run.delivery?.mode !== "foreground");
+  if (live.length === 0) return undefined;
+
+  const rows: Row[] = [];
+  for (const run of live) {
+    const stats = [formatTokens(run.usage?.tokens), formatCost(run.usage?.costUsd)]
+      .filter(Boolean)
+      .join(" · ");
+    const budget = budgetWarning(run);
+    rows.push({
+      rank: 2,
+      text: `${mark(run.state, now)} ${run.workflowName ?? "workflow"}${
+        budget ? `${AMBER}  ${budget}${RESET}` : ""
+      }`,
+      right: `${stats ? `${stats} · ` : ""}${formatElapsed(now - run.startedAt)}`,
+    });
+
+    // A checkpoint is the one thing here that a person has to act on, and it
+    // only exists as an event: the run state on disk never mentions it.
+    if (run.waiting) {
+      rows.push({
+        rank: 2,
+        text: `  ${AMBER}◆${RESET} waiting: ${run.waiting.name}`,
+        right: formatElapsed(now - run.waiting.since),
+      });
+    }
+
+    const slices = phaseSlices(run);
+    slices.forEach((slice, index) => {
+      const last = index === slices.length - 1;
+      const liveAgents = slice.agents.some(
+        (agent) => isAgentLive(agent.state),
+      );
+      const failed = slice.agents.some((agent) => agent.state === "failed");
+      const phaseState = liveAgents ? "running" : failed ? "failed" : "completed";
+
+      let cost = 0;
+      let tokens = 0;
+      for (const agent of slice.agents) {
+        cost += agent.accounting?.cost ?? 0;
+        tokens += agentTokens(agent);
+      }
+      const phaseStats = [formatTokens(tokens), formatCost(cost)].filter(Boolean).join(" · ");
+
+      rows.push({
+        rank: liveAgents || failed ? 1 : 0,
+        text: `  ${last ? "╰─" : "├─"} ${mark(phaseState, now)} ${slice.phase}`,
+        ...(phaseStats ? { right: phaseStats } : {}),
+      });
+
+      const stem = last ? "   " : "  │";
+
+      // A phase running only shell commands has no agents under it, so without
+      // this it reads as a name with nothing happening beneath it.
+      const shell = phaseShellRow(run, index, now);
+      if (shell) {
+        rows.push({
+          rank: 1,
+          text: `${stem} ${slice.agents.length === 0 ? "╰─" : "├─"} ${mark("running", now)} ${shell}`,
+        });
+      }
+
+      slice.agents.forEach((agent, agentIndex) => {
+        const lastAgent = agentIndex === slice.agents.length - 1;
+        const agentLive = isAgentLive(agent.state);
+        const attempts = agent.attempts;
+        const detail = [
+          `${agent.model.model}${agent.model.thinking ? `:${agent.model.thinking}` : ""}`,
+          formatTokens(agentTokens(agent)),
+          formatCost(agent.accounting?.cost),
+          formatElapsed(
+            agentLive && agent.startedAt ? now - agent.startedAt : (agent.durationMs ?? 0),
+          ),
+          // A retry doubles what the agent costs, and only the latest attempt
+          // shows in the numbers beside it.
+          attempts > 1 ? `attempt ${String(attempts)}` : "",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+
+        const silent = agentSilentFor(agent, run, now);
+
+        rows.push({
+          rank: agentLive || agent.state === "failed" ? 1 : 0,
+          text: `${stem} ${lastAgent ? "╰─" : "├─"} ${
+            silent === undefined
+              ? mark(agent.state, now)
+              : `${silent >= STALL_MS ? RED : AMBER}⚠${RESET}`
+          } ${agent.name}${
+            silent === undefined
+              ? ""
+              : `${silent >= STALL_MS ? RED : AMBER}  ${
+                  silent >= STALL_MS ? "stalled" : "quiet"
+                } ${formatElapsed(silent)}${RESET}`
+          }`,
+          right: detail,
+        });
+      });
+    });
+  }
+
+  const accent = BLUE;
+  const title = live.length === 1 ? "Workflow" : `Workflows · ${String(live.length)} runs`;
+  const body = collapse(rows, MAX_ROWS - 2);
+
+  // Width budget: the rule takes a column and a space on each side, so the
+  // text has four fewer than the widget is given. Every piece is measured
+  // against `inner` so the right-hand rule lands in one column on every row.
+  const inner = Math.max(20, width - 4);
+
+  // The selected row is lit the way the rest of Pi lights a selection, from
+  // the active theme rather than a colour picked here — a widget that invented
+  // its own highlight would look wrong the moment the theme changed.
+  //
+  // The row is assembled from coloured pieces, each ending in a full reset, and
+  // a full reset clears the background along with the foreground. Painted
+  // naïvely, the highlight therefore survives only on the stretches with no
+  // colour in them — the indent and the tree stem — and dies behind every piece
+  // of text. Swapping the inner resets for a foreground-only reset keeps the
+  // background alive across the whole row.
+  const FG_RESET = "\u001b[39m";
+  const highlight = (text: string): string =>
+    theme ? theme.bg("selectedBg", text.replaceAll(RESET, FG_RESET)) : text;
+
+  // Side rules only, no lid and no floor.
+  //
+  // The box is not a thing in its own right — it is a margin note against the
+  // conversation, and two horizontal rules spend two of the few lines it is
+  // worth to say so. The title rides the first row instead, where it is read
+  // in the same glance as the run beneath it.
+  const lines = body.map((row, index) => {
+    const selected = index === cursor;
+    // The numbers hold the right edge; the name gives way when the two would
+    // meet. A truncated workflow name is still recognisable, where a truncated
+    // cost is a different number.
+    const right = row.right ?? "";
+    const rightWidth = right === "" ? 0 : visibleLength(right) + 2;
+    const room = Math.max(0, inner - rightWidth);
+    const left = visibleLength(row.text) > room ? truncate(row.text, room) : row.text;
+    const gap = Math.max(0, inner - visibleLength(left) - (right === "" ? 0 : visibleLength(right)));
+    const text = right === "" ? left + " ".repeat(gap) : `${left}${" ".repeat(gap)}${DIM}${right}${RESET}`;
+    const rule = `${accent}│${RESET}`;
+    return selected ? `${rule}${highlight(` ${text} `)}${rule}` : `${rule} ${text} ${rule}`;
+  });
+
+  // The title carries the same colour as the rules it sits between: one mark
+  // in the margin, not a heading competing with the runs under it. The way in
+  // rides with it — a shortcut nobody can see is a shortcut nobody uses — and
+  // gives way to the title if the terminal is too narrow for both.
+  const hint = cursor === undefined ? `↓ or ${FOCUS_SHORTCUT}` : "↑↓ move · esc back";
+  const room = inner - visibleLength(title);
+  const withHint =
+    room >= visibleLength(hint) + 2
+      ? `${title}${" ".repeat(room - visibleLength(hint))}${hint}`
+      : `${title}${" ".repeat(Math.max(0, room))}`;
+  const heading = `${accent}│ ${withHint} │${RESET}`;
+  return [heading, ...lines];
+}
+
+/** Everything worth keeping about a run once it is over. */
+/**
+ * How many tool calls an agent made, counted from its transcript.
+ *
+ * `toolCalls` on the agent record is empty on disk — it is filled in memory and
+ * only persisted at moments that have usually passed by the time a run ends.
+ * The transcript is the durable record: every turn is appended as it happens.
+ */
+function countToolCalls(run: Run, index: number): number | undefined {
+  const session = (run.agentSessions ?? [])[index];
+  const locator = session?.locator as { sessionFile?: string } | undefined;
+  const file = locator?.sessionFile;
+  if (!file) return undefined;
+  try {
+    let calls = 0;
+    for (const line of readFileSync(file, "utf8").split("\n")) {
+      if (line === "") continue;
+      const entry = JSON.parse(line) as { type?: string; message?: { content?: readonly { type?: string }[] } };
+      if (entry.type !== "message") continue;
+      for (const part of entry.message?.content ?? []) if (part.type === "toolCall") calls += 1;
+    }
+    return calls;
+  } catch {
+    // The transcript was cleaned up, or is mid-write. A missing count is
+    // better than a wrong one.
+    return undefined;
+  }
+}
+
+function receiptFor(run: Run): Receipt {
+  const agents = run.agents ?? [];
+  return {
+    runId: run.id ?? "",
+    workflow: run.workflowName ?? "workflow",
+    state: run.state ?? "completed",
+    costUsd: run.usage?.costUsd ?? 0,
+    tokens: run.usage?.tokens ?? 0,
+    durationMs: run.usage?.durationMs ?? 0,
+    phases: (run.phaseHistory ?? []).map((entry) => entry.phase),
+    // Agents carry no phase of their own; phaseHistory records how many had
+    // finished when each phase opened, so these offsets are what tie them.
+    phaseBoundaries: (run.phaseHistory ?? []).map((entry) => entry.afterAgent),
+    agents: agents.map((agent, index) => {
+      const calls = countToolCalls(run, index);
+      return {
+        name: agent.name,
+        state: agent.state,
+        // Model and thinking level together: a role picks both, and the model
+        // name alone does not say whether it reasoned cheaply or deeply.
+        ...(agent.model.model
+          ? {
+              model: `${agent.model.model}${agent.model.thinking ? `:${agent.model.thinking}` : ""}`,
+            }
+          : {}),
+        ...(agent.role ? { role: agent.role } : {}),
+        ...(agent.requestedModel ? { requestedModel: agent.requestedModel } : {}),
+        // What the agent actually did, not what it was allowed to do. The
+        // permitted toolbox is a property of the role and says nothing about
+        // this particular run; the number of calls says how hard it worked.
+        ...(calls === undefined ? {} : { toolCalls: calls }),
+        // Cache reads dwarf real input and cost almost nothing, so the split is
+        // what explains a cheap run that looks enormous.
+        input: agent.accounting?.input ?? 0,
+        output: agent.accounting?.output ?? 0,
+        cacheRead: agent.accounting?.cacheRead ?? 0,
+        costUsd: agent.accounting?.cost ?? 0,
+        durationMs: agent.durationMs ?? 0,
+        attempts: agent.attempts,
+      };
+    }),
+    ...(run.error?.message ? { error: run.error.message } : {}),
+  };
+}
+
+/** The receipt as transcript lines: the widget's tree, one level deeper. */
+export function renderReceipt(data: Receipt, expanded: boolean, theme: Theme): string[] {
+  const glyph = (state: string): string =>
+    state === "completed"
+      ? theme.fg("success", "✓")
+      : state === "failed" || state === "budget_exhausted"
+        ? theme.fg("error", "✗")
+        : theme.fg("muted", "·");
+
+  const headline = [
+    formatTokens(data.tokens),
+    formatCost(data.costUsd) || "$0.00",
+    formatElapsed(data.durationMs),
+    data.state,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const lines = [`${glyph(data.state)} ${theme.bold(data.workflow)} ${theme.fg("muted", headline)}`];
+
+  data.phases.forEach((phase, index) => {
+    const from = data.phaseBoundaries[index] ?? 0;
+    const to =
+      index + 1 < data.phaseBoundaries.length
+        ? (data.phaseBoundaries[index + 1] ?? data.agents.length)
+        : data.agents.length;
+    const agents = data.agents.slice(from, to);
+    const last = index === data.phases.length - 1;
+
+    let cost = 0;
+    let tokens = 0;
+    for (const agent of agents) {
+      cost += agent.costUsd;
+      tokens += agent.input + agent.output;
+    }
+    const state = agents.some((agent) => agent.state === "failed") ? "failed" : "completed";
+    const stats = [formatTokens(tokens), formatCost(cost)].filter(Boolean).join(" · ");
+
+    lines.push(
+      `${last ? "╰─" : "├─"} ${glyph(state)} ${phase}${stats ? theme.fg("muted", `  ${stats}`) : ""}`,
+    );
+
+    const stem = last ? "  " : "│ ";
+    agents.forEach((agent, agentIndex) => {
+      const lastAgent = agentIndex === agents.length - 1;
+      const detail = [
+        agent.model ?? "",
+        formatCost(agent.costUsd),
+        formatElapsed(agent.durationMs),
+        // A run that only succeeded on the third try cost three times what its
+        // final attempt suggests.
+        agent.attempts > 1 ? `${String(agent.attempts)} attempts` : "",
+      ]
+        .filter(Boolean)
+        .join(" · ");
+
+      lines.push(
+        `${stem} ${lastAgent ? "╰─" : "├─"} ${glyph(agent.state)} ${agent.name} ${theme.fg("muted", detail)}`,
+      );
+
+      const under = `${stem} ${lastAgent ? "  " : "│ "}   `;
+      const meta = [
+        agent.role ? `role ${agent.role}` : "",
+        agent.requestedModel && agent.requestedModel !== agent.model
+          ? `via ${agent.requestedModel}`
+          : "",
+        agent.toolCalls === undefined
+          ? ""
+          : `${String(agent.toolCalls)} ${agent.toolCalls === 1 ? "call" : "calls"}`,
+      ].filter(Boolean);
+      if (meta.length > 0) lines.push(theme.fg("muted", `${under}${meta.join(" · ")}`));
+
+      const split = [
+        agent.input ? `in ${formatTokens(agent.input)}` : "",
+        agent.output ? `out ${formatTokens(agent.output)}` : "",
+        agent.cacheRead ? `cache ${formatTokens(agent.cacheRead)}` : "",
+      ].filter(Boolean);
+      if (split.length > 0) lines.push(theme.fg("muted", `${under}${split.join(" · ")}`));
+    });
+  });
+
+  if (data.error !== undefined) lines.push(theme.fg("error", `   ${data.error}`));
+
+  // The run id is only useful when acting on it (resuming, digging through the
+  // run directory), so it stays out of the way until the entry is expanded.
+  if (expanded && data.runId) lines.push(theme.fg("muted", `   run ${data.runId}`));
+
+  return lines;
+}
+
+export default function widget(pi: ExtensionAPI): void {
+  let context: ExtensionContext | undefined;
+  let timer: NodeJS.Timeout | undefined;
+  /** True while a frame is on screen, so it is only cleared when there is one. */
+  let showing = false;
+
+  /**
+   * Whether the widget holds the keyboard, and which row is under the cursor.
+   *
+   * Focus is only taken deliberately — `↓` on an empty editor — and given back
+   * the moment anything is typed. A widget that swallowed keys the rest of the
+   * time would be a widget you had to fight to write past.
+   */
+  let focused = false;
+  let cursor = 0;
+  /** Rows in the last frame, so the cursor cannot leave it. */
+  let rowCount = 0;
+  /**
+   * The TUI the widget was last built against, kept only to ask whether
+   * something else currently owns the keyboard.
+   */
+  let host: TuiHandle | undefined;
+
+  /**
+   * Whether some other component is holding the keyboard.
+   *
+   * `↓` from an empty editor is the comfortable way in, but an empty editor is
+   * also what every picker and dialog leaves behind while it waits for arrows.
+   * Claiming the key regardless meant `/workflow` opened a menu that could not
+   * be moved through.
+   *
+   * The editor holds focus whenever nothing special is open, so the question is
+   * whether focus is still on an editor — recognised by what it can do, not by
+   * `instanceof`. A widget is installed beside Pi rather than inside it, and npm
+   * may well give it a second copy of the TUI package: the classes then differ
+   * by identity even though they are the same class, and `instanceof` answers
+   * "not an editor" for the editor itself. Duck typing survives that.
+   */
+  const somethingElseHasTheKeyboard = (): boolean => {
+    try {
+      if (host?.hasOverlay?.()) return true;
+      const focus = host?.getFocusedComponent?.() as { getText?: unknown; addToHistory?: unknown } | null | undefined;
+      if (focus === undefined) return false;
+      if (focus === null) return false;
+      return typeof focus.getText !== "function" || typeof focus.addToHistory !== "function";
+    } catch {
+      // An older TUI without these accessors: assume the coast is clear rather
+      // than disabling navigation outright.
+      return false;
+    }
+  };
+
+  /** Run directories seen this session, and the parsed state of each. */
+  const runs = new Map<string, Run>();
+  /** Last-seen mtime per run, so an unchanged state file is never re-parsed. */
+  const seen = new Map<string, number>();
+  /** Runs already written to the transcript, so each is recorded once. */
+  const receipted = new Set<string>();
+
+  const sessionId = (): string | undefined => context?.sessionManager.getSessionId();
+
+  /** Re-read one run's state. Called on events, never on the repaint timer. */
+  const refresh = (runId: string, directory: string, runSessionId: string): void => {
+    // A run filed under another session belongs to another window's widget.
+    if (runSessionId !== sessionId()) return;
+    const run = readRun(directory);
+    if (!run) return;
+    // A pending checkpoint is known only from events, so it has to survive a
+    // re-read of the state file that knows nothing about it.
+    const waiting = runs.get(runId)?.waiting;
+    runs.set(runId, waiting ? { ...run, waiting } : run);
+  };
+
+  const receipt = (runId: string): void => {
+    if (receipted.has(runId)) return;
+    const run = runs.get(runId);
+    if (!run) return;
+    receipted.add(runId);
+    runs.delete(runId);
+    // A foreground run already left its own summary in the transcript, put
+    // there by the workflow tool call that waited for it. A second account of
+    // the same run directly beneath the first is noise.
+    if (run.delivery?.mode === "foreground") return;
+    pi.appendEntry<Receipt>(ENTRY_TYPE, receiptFor(run));
+  };
+
+  const paint = (): void => {
+    if (!context?.hasUI) return;
+    if (!renderFrame([...runs.values()], Date.now(), 80)) {
+      if (showing) {
+        context.ui.setWidget(KEY, undefined);
+        showing = false;
+      }
+      return;
+    }
+
+    // Registered as a factory so the frame is built at the width the TUI is
+    // about to draw with, read in the same pass that validates it. Reading the
+    // terminal separately races a pane split: the frame is built at one width
+    // and checked against another, and Pi treats an over-wide line as fatal
+    // rather than wrapping it. Every row is clamped again on the way out, so
+    // the worst case is a clipped row instead of a crashed session.
+    context.ui.setWidget(
+      KEY,
+      (tui: TuiHandle, theme: Theme) => {
+        // Held so the input handler can ask who owns the keyboard right now.
+        host = tui;
+        return {
+          render: (width: number): string[] => {
+            const usable = Math.max(20, width);
+            const frame = renderFrame([...runs.values()], Date.now(), usable, focused ? cursor : undefined, theme) ?? [];
+            rowCount = frame.length - 1;
+            return frame.map((line) =>
+              visibleLength(line) > usable ? truncate(line, usable) : line,
+            );
+          },
+          invalidate: (): void => {
+            // Nothing is cached between frames; every render reads current state.
+          },
+        };
+      },
+      // Below the editor, where a running job belongs: it is something to
+      // glance down at, not something standing between the conversation and
+      // the place you type.
+      { placement: "belowEditor" },
+    );
+    showing = true;
+  };
+
+  /**
+   * Re-read any run whose state file changed since the last look.
+   *
+   * Events cover agents and phases, but shell activity is written to the state
+   * file without one: a phase running nothing but `shell` would sit unchanged
+   * on screen until some unrelated event happened to arrive. A stat per live
+   * run is cheap next to parsing one — the check costs a few microseconds and
+   * only the changed file is read.
+   */
+  const rescan = (): void => {
+    for (const [runId, run] of runs) {
+      try {
+        const mtime = statSync(join(run.directory, "state.json")).mtimeMs;
+        if (mtime === seen.get(runId)) continue;
+        seen.set(runId, mtime);
+        const fresh = readRun(run.directory);
+        if (fresh) runs.set(runId, run.waiting ? { ...fresh, waiting: run.waiting } : fresh);
+      } catch {
+        // The run's directory went away, or is mid-write. Keep what we have.
+      }
+    }
+  };
+
+  const tick = (): void => {
+    try {
+      rescan();
+      paint();
+    } catch {
+      // A failed repaint is a skipped frame, never fatal: a widget that dies
+      // quietly is indistinguishable from one that was never drawn.
+      showing = false;
+    }
+  };
+
+  // The transcript entry: appendEntry carries the data, this renders it. It
+  // returns a plain component rather than importing pi-tui's Text, because
+  // @earendil-works/pi-tui only resolves inside Pi's own module tree.
+  pi.registerEntryRenderer<Receipt>(ENTRY_TYPE, (entry, options, theme) => {
+    if (!entry.data) return undefined;
+    const lines = renderReceipt(entry.data, options.expanded, theme);
+    return {
+      // The width has to be honoured here as much as in the widget: Pi treats
+      // an over-wide line as fatal rather than wrapping it, and a receipt can
+      // carry a long line — a toolbox listing, a failure message — that no
+      // amount of care at build time can bound.
+      render: (width: number): string[] =>
+        lines.map((line) => (visibleLength(line) > width ? truncate(line, width) : line)),
+      invalidate: (): undefined => undefined,
+    };
+  });
+
+  const onRunEvent = (event: unknown): void => {
+    const { runId, runDirectory, sessionId: eventSession } = event as {
+      runId?: string;
+      runDirectory?: string;
+      sessionId?: string;
+    };
+    if (!runId || !runDirectory || !eventSession) return;
+    refresh(runId, runDirectory, eventSession);
+    tick();
+  };
+
+  /** Unsubscribe callbacks, so this instance can leave the bus as it found it. */
+  const unsubscribes: (() => void)[] = [];
+
+  for (const name of [
+    WORKFLOW_RUN_STARTED_EVENT,
+    WORKFLOW_RUN_STATE_CHANGED_EVENT,
+    WORKFLOW_AGENT_STATE_CHANGED_EVENT,
+    WORKFLOW_PHASE_CHANGED_EVENT,
+    WORKFLOW_BUDGET_EVENT,
+  ]) {
+    unsubscribes.push(pi.events.on(name, onRunEvent));
+  }
+
+  unsubscribes.push(
+    pi.events.on(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, (event: unknown) => {
+      const { runId, name, state } = event as {
+        runId?: string;
+        name?: string;
+        state?: string;
+      };
+      if (!runId) return;
+      const run = runs.get(runId);
+      if (!run) return;
+      if (state === "awaiting") {
+        runs.set(runId, { ...run, waiting: { name: name ?? "checkpoint", since: Date.now() } });
+      } else {
+        // Drop the key entirely rather than setting it undefined: the package
+        // builds with exactOptionalPropertyTypes.
+        const answered = { ...run };
+        delete answered.waiting;
+        runs.set(runId, answered);
+      }
+      tick();
+    }),
+  );
+
+  for (const name of [WORKFLOW_RUN_COMPLETED_EVENT, WORKFLOW_RUN_FAILED_EVENT]) {
+    unsubscribes.push(
+      pi.events.on(name, (event: unknown) => {
+        const { runId } = event as { runId?: string };
+        onRunEvent(event);
+        // The terminal state lands in state.json just after the event, so the
+        // receipt is taken on the next tick rather than this one.
+        if (runId) setTimeout(() => { receipt(runId); tick(); }, 100).unref();
+      }),
+    );
+  }
+
+  const stop = (): void => {
+    if (timer) clearInterval(timer);
+    timer = undefined;
+    if (showing) context?.ui.setWidget(KEY, undefined);
+    showing = false;
+    focused = false;
+    for (const unsubscribe of unsubscribes.splice(0)) unsubscribe();
+  };
+
+
+  pi.on("session_start", (_event, sessionContext) => {
+    context = sessionContext;
+    // The core drops every extension widget when a session starts or reloads,
+    // so nothing of this instance is on screen at this point.
+    showing = false;
+
+    // Replay what the session already recorded so a reload cannot write the
+    // same run into the transcript twice.
+    receipted.clear();
+    try {
+      for (const entry of sessionContext.sessionManager.getEntries()) {
+        const custom = entry as { type?: string; customType?: string; data?: { runId?: string } };
+        if (custom.type !== "custom" || custom.customType !== ENTRY_TYPE) continue;
+        if (custom.data?.runId) receipted.add(custom.data.runId);
+      }
+    } catch {
+      // No history to read; runs from this session on are recorded anyway.
+    }
+
+    if (!timer) {
+      timer = setInterval(tick, REPAINT_MS);
+      // Never hold the process open for the sake of a status line.
+      timer.unref();
+    }
+
+    // Keyboard access, taken as lightly as possible.
+    //
+    // Keyboard access, taken as lightly as possible.
+    //
+    // The handler sees every keystroke before the editor does, so it declines
+    // all but a few. `↓` on an empty editor is the natural way in — the same
+    // gesture Claude Code uses for its agent dock — but an empty editor is also
+    // what every picker and dialog leaves behind while it waits for arrows, so
+    // the key is only claimed once the TUI confirms nothing else is focused.
+    // The shortcut is the way in that never has to share.
+    unsubscribes.push(
+      sessionContext.ui.onTerminalInput((data: string) => {
+        if (!showing) return undefined;
+
+        if (focused) {
+          // Something opened over the widget while it held the keyboard — a
+          // command picker, a dialog. It has the better claim.
+          if (somethingElseHasTheKeyboard()) {
+            focused = false;
+            return undefined;
+          }
+          // The tail of a keystroke already acted on. Swallow it so it cannot
+          // reach the editor, but do not move twice for one press.
+          if (isKeyRelease(data)) return { consume: true };
+          if (matchesKey(data, Key.up)) {
+            cursor = Math.max(0, cursor - 1);
+            return { consume: true };
+          }
+          if (matchesKey(data, Key.down)) {
+            cursor = Math.min(Math.max(0, rowCount - 1), cursor + 1);
+            return { consume: true };
+          }
+          if (matchesKey(data, Key.escape) || data === "q") {
+            focused = false;
+            return { consume: true };
+          }
+          // Anything else is someone typing: hand the keyboard back and let
+          // the keystroke through, so a thought is never lost to a panel.
+          focused = false;
+          return undefined;
+        }
+
+        if (isKeyRelease(data)) return undefined;
+        if (!matchesKey(data, Key.down)) return undefined;
+        // A menu is open, or focus has left the editor: the arrows are not
+        // ours to take.
+        if (somethingElseHasTheKeyboard()) return undefined;
+        let empty = false;
+        try {
+          empty = sessionContext.ui.getEditorText().trim() === "";
+        } catch {
+          // No editor to consult; leave the key alone.
+        }
+        if (!empty) return undefined;
+        focused = true;
+        cursor = 0;
+        return { consume: true };
+      }),
+    );
+
+    tick();
+  });
+
+  // A way in that never competes. `↓` is the comfortable gesture but it is
+  // shared with every picker; the shortcut answers whatever else is on screen,
+  // and Pi lets it be rebound in `keybindings.json` like any other.
+  pi.registerShortcut(FOCUS_SHORTCUT, {
+    description: "Focus the workflow widget",
+    handler: () => {
+      if (!showing) return;
+      focused = !focused;
+      cursor = 0;
+    },
+  });
+
+  pi.on("session_shutdown", stop);
+}

--- a/packages/extensions/widget/index.ts
+++ b/packages/extensions/widget/index.ts
@@ -16,7 +16,7 @@
 import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
-import { isKeyRelease, Key, matchesKey } from "@earendil-works/pi-tui";
+import { isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { AgentRecord, AgentState, RunRecord, RunState } from "pi-extensible-workflows";
 import {
   WORKFLOW_AGENT_STALL_THRESHOLD_MS,
@@ -47,7 +47,15 @@ const REPAINT_MS = 125;
  * rather than a limit imposed from outside. What does not fit is folded away by
  * rank, so live work survives and finished work is dropped first.
  */
-const MAX_ROWS = 20;
+/**
+ * Rows the widget will occupy, border included.
+ *
+ * Ten is a deliberate ceiling rather than a technical one: the widget sits
+ * under the editor, and anything taller pushes the conversation off the top of
+ * a normal terminal to report on work that is, by definition, happening
+ * elsewhere. Deeper detail is a keypress away rather than always on screen.
+ */
+const MAX_ROWS = 10;
 
 /**
  * Key matching belongs to Pi, not here.
@@ -98,12 +106,50 @@ const SHELL_VISIBLE_MS = 5000;
  */
 const FOCUS_SHORTCUT = "alt+o";
 
-const BLUE = "\x1b[38;2;77;163;255m";
-const RED = "\x1b[38;2;235;87;87m";
-const GREEN = "\x1b[38;2;95;186;125m";
-const AMBER = "\x1b[38;2;222;158;65m";
-const DIM = "\x1b[38;2;120;120;120m";
+/**
+ * Whether the widget accepts the keyboard.
+ *
+ * Scrolling earns its keys: ten rows cannot hold five runs three phases deep,
+ * and what gets folded away at rest is the widget's choice rather than the
+ * reader's. The shortcut is the only way in — `↓` on an empty editor belongs
+ * to whichever picker opens next.
+ */
+const NAVIGATION_ENABLED = true;
+
+/**
+ * Overrides the switch above, for the tests that cover navigation.
+ *
+ * The behaviour is finished and tested; only its exposure is withheld. Letting
+ * the tests turn it on keeps that coverage alive rather than letting it rot
+ * while the feature waits.
+ */
+export const __navigationForTests = { enabled: NAVIGATION_ENABLED };
+
+/**
+ * Colours come from the active theme, never from here.
+ *
+ * A widget that spelled out its own 24-bit escapes would look right on the
+ * author's terminal and wrong on a 256-colour or light theme, and would ignore
+ * whatever the reader chose. `Theme.fg` resolves a named role against the
+ * theme in force, so the widget follows it.
+ *
+ * These names are the roles used, kept in one place so a colour decision is
+ * visible as a decision rather than scattered through the drawing code.
+ */
+const ROLE = {
+  live: "accent",
+  done: "success",
+  failed: "error",
+  warn: "warning",
+  quiet: "muted",
+} as const satisfies Record<string, Parameters<Theme["fg"]>[0]>;
 const RESET = "\x1b[0m";
+
+/**
+ * Paints text in a themed colour role. Falls back to the bare text when no
+ * theme is available, so a frame rendered outside the TUI is still legible.
+ */
+type Paint = (role: Parameters<Theme["fg"]>[0], text: string) => string;
 
 /**
  * States that mean work is still happening, derived from the core's own lists
@@ -185,11 +231,11 @@ function spinner(now: number): string {
 }
 
 /** Status mark for a finished-or-running unit of work. */
-function mark(state: string | undefined, now: number): string {
-  if (isAgentLive(state) && isRunLive(state)) return `${BLUE}${spinner(now)}${RESET}`;
-  if (state === "completed") return `${GREEN}✓${RESET}`;
-  if (state === "failed" || state === "budget_exhausted") return `${RED}✗${RESET}`;
-  return `${DIM}·${RESET}`;
+function mark(state: string | undefined, now: number, paint: Paint): string {
+  if (isAgentLive(state) && isRunLive(state)) return paint(ROLE.live, spinner(now));
+  if (state === "completed") return paint(ROLE.done, "✓");
+  if (state === "failed" || state === "budget_exhausted") return paint(ROLE.failed, "✗");
+  return paint(ROLE.quiet, "·");
 }
 
 function formatElapsed(ms: number): string {
@@ -213,39 +259,29 @@ function formatCost(cost: number | undefined): string {
   return cost < 0.01 ? `$${cost.toFixed(3)}` : `$${cost.toFixed(2)}`;
 }
 
-/** Visible width, ignoring ANSI colour codes, so the border lines up. */
+/**
+ * Visible width, measured the way the terminal measures it.
+ *
+ * Not the string's length: a CJK ideograph is one JavaScript character and two
+ * terminal cells, an emoji is often two characters and two cells, and a
+ * combining accent is a character that takes none. Pi-tui rejects a line wider
+ * than the width it handed out — it does not wrap, it throws — so the widget
+ * has to agree with it exactly, and the only way to agree exactly is to use
+ * its own measure.
+ */
 function visibleLength(text: string): number {
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/\x1b\[[0-9;]*m/g, "").length;
+  return visibleWidth(text);
 }
 
 /**
  * Cuts a coloured line down to a visible width.
  *
- * Walks the string rather than slicing it: an escape sequence costs no columns
- * but plenty of characters, so a plain slice either cuts mid-escape — bleeding
- * colour into the border — or stops far short of the width it was given.
+ * Pi-tui's own truncation, for the same reason: it counts cells, keeps escape
+ * sequences whole rather than slicing through one and bleeding colour into the
+ * border, and never cuts a character in half.
  */
 function truncate(text: string, limit: number): string {
-  let out = "";
-  let visible = 0;
-  let index = 0;
-  while (index < text.length) {
-    // eslint-disable-next-line no-control-regex
-    const escape = /^\x1b\[[0-9;]*m/.exec(text.slice(index));
-    if (escape?.[0]) {
-      out += escape[0];
-      index += escape[0].length;
-      continue;
-    }
-    if (visible >= limit - 1) break;
-    const character = text[index];
-    if (character === undefined) break;
-    out += character;
-    visible += 1;
-    index += 1;
-  }
-  return `${out}…${RESET}`;
+  return `${truncateToWidth(text, limit, "…")}${RESET}`;
 }
 
 /**
@@ -275,18 +311,37 @@ function readRun(directory: string): Run | undefined {
  * hand, is appended to on every turn — if that file is growing, work is
  * happening, whatever the run state says.
  */
-function lastTranscriptWrite(run: Run): number | undefined {
+/**
+ * When an agent's own transcript was last written.
+ *
+ * The agent record carries the session for each attempt, so the file belongs
+ * to this agent alone. Taking the newest write across every session in the run
+ * — as a whole-run reading does — lets one busy agent vouch for a silent one:
+ * the pair look equally alive while only one of them is.
+ *
+ * Stat results are cached for the life of a frame. Without that the check is
+ * one stat per agent per repaint, several times a second, for a number that
+ * cannot have changed between two rows of the same frame.
+ */
+function lastTranscriptWrite(agent: AgentRecord, cache: Map<string, number | undefined>): number | undefined {
+  const details = agent.attemptDetails ?? [];
   let newest: number | undefined;
-  for (const session of run.agentSessions ?? []) {
-    const locator = session.locator as { sessionFile?: string } | undefined;
+  // Only this agent's attempts: a retry writes a new transcript, and the
+  // latest one is what says whether it is still moving.
+  for (const detail of details) {
+    const locator = detail.session?.locator as { sessionFile?: string } | undefined;
     const file = locator?.sessionFile;
     if (!file) continue;
-    try {
-      const { mtimeMs } = statSync(file);
-      if (newest === undefined || mtimeMs > newest) newest = mtimeMs;
-    } catch {
-      // The transcript moved or was cleaned up; other sessions may still answer.
+    if (!cache.has(file)) {
+      try {
+        cache.set(file, statSync(file).mtimeMs);
+      } catch {
+        // The transcript moved or was cleaned up; another attempt may answer.
+        cache.set(file, undefined);
+      }
     }
+    const mtime = cache.get(file);
+    if (mtime !== undefined && (newest === undefined || mtime > newest)) newest = mtime;
   }
   return newest;
 }
@@ -298,9 +353,9 @@ function lastTranscriptWrite(run: Run): number | undefined {
  * are a spinner that does not stop. Silence separates them — but it has to be
  * measured against the transcript, not the run state.
  */
-function agentSilentFor(agent: AgentRecord, run: Run, now: number): number | undefined {
+function agentSilentFor(agent: AgentRecord, now: number, cache: Map<string, number | undefined>): number | undefined {
   if (!isAgentLive(agent.state)) return undefined;
-  const last = Math.max(agent.lastEventAt ?? 0, lastTranscriptWrite(run) ?? 0);
+  const last = Math.max(agent.lastEventAt ?? 0, lastTranscriptWrite(agent, cache) ?? 0);
   if (last === 0) return undefined;
   const silent = now - last;
   return silent >= QUIET_MS ? silent : undefined;
@@ -312,14 +367,16 @@ function agentSilentFor(agent: AgentRecord, run: Run, now: number): number | und
  * A phase of pure shell work has no agents, so without this it draws as a bare
  * name with nothing under it and reads as stalled.
  */
-function phaseShellRow(run: Run, phaseIndex: number, now: number): string | undefined {
+function phaseShellRow(run: Run, phaseIndex: number, now: number): { label: string; elapsed: string } | undefined {
   const entry = run.activeShellsByPhase?.find((item) => item.phaseIndex === phaseIndex);
   const active = entry?.active ?? 0;
   if (active <= 0) return undefined;
   const startedAt = entry?.startedAt;
   if (startedAt === undefined || now - startedAt < SHELL_VISIBLE_MS) return undefined;
   const label = active === 1 ? "1 command" : `${String(active)} commands`;
-  return `${label}${DIM} · ${formatElapsed(now - startedAt)}${RESET}`;
+  // The elapsed time is returned apart from the label so it can join the other
+  // figures against the right-hand rule instead of trailing the text.
+  return { label, elapsed: formatElapsed(now - startedAt) };
 }
 
 /** The worst budget threshold a run has crossed, and on which dimensions. */
@@ -380,8 +437,25 @@ interface Row {
    * Held to the right edge, they form a column.
    */
   right?: string;
-  /** 2 = run header (never folded), 1 = live or failed, 0 = finished detail. */
+  /** 2 = a run header or something needing an answer, 1 = live or failed work, 0 = finished detail. */
   rank: number;
+  /**
+   * Set on the one row that stands for a whole run.
+   *
+   * Rank alone cannot protect it: a checkpoint needs an answer and so shares
+   * the top rank, and enough of them would spend the budget before a later
+   * run's header is reached. A run missing its header is not a terse run, it
+   * is an invisible one.
+   */
+  header?: boolean;
+  /**
+   * A stable name for a row that can be folded shut, and the key of the row it
+   * hangs from. Together they let the cursor walk a tree rather than a list:
+   * collapsing a phase hides its agents, collapsing a run hides everything
+   * under it, and the choice survives the repaint that follows.
+   */
+  key?: string;
+  parent?: string;
 }
 
 /**
@@ -389,10 +463,48 @@ interface Row {
  * leaving a marker in their place. Run headers always survive: losing one hides
  * a whole run rather than a detail of it.
  */
-function collapse(rows: readonly Row[], budget: number): Row[] {
+/**
+ * The furthest the window may travel: the offset whose window ends on the last
+ * row of the tree.
+ *
+ * One number, used by the window, by the scrollbar and by the key handler
+ * alike. Three separate clamps is how the thumb reaches the bottom while the
+ * content still has rows to give, and how presses past the end pile up an
+ * offset nothing can see — paid back later as arrow presses that do nothing.
+ */
+function maxOffset(total: number, budget: number): number {
+  return Math.max(0, total - (budget - 1));
+}
+
+function collapse(rows: readonly Row[], budget: number, paint: Paint, offset: number, scrolling: boolean): Row[] {
   if (rows.length <= budget) return [...rows];
 
+  // Scrolling: a window onto the tree, with the count of what lies past the
+  // bottom edge. Reading it is a matter of moving the window rather than
+  // deciding for the reader which rows deserve the space.
+  //
+  // The window is used from the moment scrolling starts, offset zero included.
+  // Entering at the resting view instead would show a set of rows picked by
+  // rank — non-contiguous, with the gaps unmarked — and the first press would
+  // then jump to a different set entirely rather than moving by one row.
+  if (scrolling) {
+    const start = Math.min(offset, maxOffset(rows.length, budget));
+    const window = rows.slice(start, start + budget - 1);
+    const below = rows.length - start - window.length;
+    const out = [...window];
+    out.push({ rank: 0, text: paint(ROLE.quiet, below > 0 ? `… ${String(below)} more` : `… ${String(start)} above`) });
+    return out;
+  }
+
+  // At rest: keep the rows that say most, since nobody is steering. Run
+  // headers first, then live or failed work, then finished detail.
+  //
+  // Headers are taken before anything else at the same rank, and taken whole:
+  // a run whose header is dropped vanishes from the widget entirely, while a
+  // run that loses its detail rows is merely terse. Ranking alone would let
+  // one early run's checkpoints spend the budget and hide a later run.
   const keep = new Set<number>();
+  for (const [index, row] of rows.entries()) if (row.rank === 2 && row.header === true) keep.add(index);
   for (const rank of [2, 1, 0]) {
     for (const [index, row] of rows.entries()) {
       if (row.rank === rank && keep.size < budget - 1) keep.add(index);
@@ -408,12 +520,14 @@ function collapse(rows: readonly Row[], budget: number): Row[] {
       hidden += 1;
     }
   }
-  if (hidden > 0) out.push({ rank: 0, text: `${DIM}… ${String(hidden)} more${RESET}` });
+  if (hidden > 0) out.push({ rank: 0, text: paint(ROLE.quiet, `… ${String(hidden)} more`) });
   return out;
 }
 
+
+
 /** The whole widget frame, or undefined when nothing is running. */
-function renderFrame(runs: readonly Run[], now: number, width: number, cursor?: number, theme?: Theme): string[] | undefined {
+function renderFrame(runs: readonly Run[], now: number, width: number, offset = 0, theme?: Theme, scrolling = false, sizeOut: { rows: number } = { rows: 0 }): string[] | undefined {
   // Only live background runs.
   //
   // A finished run leaves its own receipt in the transcript, so holding it
@@ -428,16 +542,23 @@ function renderFrame(runs: readonly Run[], now: number, width: number, cursor?: 
   const live = runs.filter((run) => isRunLive(run.state) && run.delivery?.mode !== "foreground");
   if (live.length === 0) return undefined;
 
+  const paint: Paint = (role, text) => (theme ? theme.fg(role, text) : text);
+  // One stat per transcript per frame, not per agent per repaint.
+  const mtimes = new Map<string, number | undefined>();
+
   const rows: Row[] = [];
   for (const run of live) {
     const stats = [formatTokens(run.usage?.tokens), formatCost(run.usage?.costUsd)]
       .filter(Boolean)
       .join(" · ");
     const budget = budgetWarning(run);
+    const runKey = `run:${run.id ?? ""}`;
     rows.push({
       rank: 2,
-      text: `${mark(run.state, now)} ${run.workflowName ?? "workflow"}${
-        budget ? `${AMBER}  ${budget}${RESET}` : ""
+      header: true,
+      key: runKey,
+      text: `${mark(run.state, now, paint)} ${run.workflowName ?? "workflow"}${
+        budget ? `  ${paint(ROLE.warn, budget)}` : ""
       }`,
       right: `${stats ? `${stats} · ` : ""}${formatElapsed(now - run.startedAt)}`,
     });
@@ -447,7 +568,8 @@ function renderFrame(runs: readonly Run[], now: number, width: number, cursor?: 
     if (run.waiting) {
       rows.push({
         rank: 2,
-        text: `  ${AMBER}◆${RESET} waiting: ${run.waiting.name}`,
+        parent: runKey,
+        text: `  ${paint(ROLE.warn, "◆")} waiting: ${run.waiting.name}`,
         right: formatElapsed(now - run.waiting.since),
       });
     }
@@ -469,9 +591,12 @@ function renderFrame(runs: readonly Run[], now: number, width: number, cursor?: 
       }
       const phaseStats = [formatTokens(tokens), formatCost(cost)].filter(Boolean).join(" · ");
 
+      const phaseKey = `${runKey}/phase:${String(index)}`;
       rows.push({
         rank: liveAgents || failed ? 1 : 0,
-        text: `  ${last ? "╰─" : "├─"} ${mark(phaseState, now)} ${slice.phase}`,
+        key: phaseKey,
+        parent: runKey,
+        text: `  ${last ? "╰─" : "├─"} ${mark(phaseState, now, paint)} ${slice.phase}`,
         ...(phaseStats ? { right: phaseStats } : {}),
       });
 
@@ -483,12 +608,28 @@ function renderFrame(runs: readonly Run[], now: number, width: number, cursor?: 
       if (shell) {
         rows.push({
           rank: 1,
-          text: `${stem} ${slice.agents.length === 0 ? "╰─" : "├─"} ${mark("running", now)} ${shell}`,
+          parent: phaseKey,
+          text: `${stem} ${slice.agents.length === 0 ? "╰─" : "├─"} ${mark("running", now, paint)} ${shell.label}`,
+          right: shell.elapsed,
         });
       }
 
-      slice.agents.forEach((agent, agentIndex) => {
-        const lastAgent = agentIndex === slice.agents.length - 1;
+      // Agents nest: one may spawn another, and drawing them as siblings hides
+      // who asked for what — a child's cost then reads as a peer's rather than
+      // part of the parent's total.
+      const children = new Map<string, AgentRecord[]>();
+      const roots: AgentRecord[] = [];
+      const inSlice = new Set(slice.agents.map((agent) => agent.id));
+      for (const agent of slice.agents) {
+        const parent = agent.parentId;
+        if (parent !== undefined && inSlice.has(parent)) {
+          children.set(parent, [...(children.get(parent) ?? []), agent]);
+        } else {
+          roots.push(agent);
+        }
+      }
+
+      const drawAgent = (agent: AgentRecord, prefix: string, lastAgent: boolean, parentKey: string): void => {
         const agentLive = isAgentLive(agent.state);
         const attempts = agent.attempts;
         const detail = [
@@ -505,58 +646,90 @@ function renderFrame(runs: readonly Run[], now: number, width: number, cursor?: 
           .filter(Boolean)
           .join(" · ");
 
-        const silent = agentSilentFor(agent, run, now);
+        const silent = agentSilentFor(agent, now, mtimes);
+        const kids = children.get(agent.id) ?? [];
+        const agentKey = `${parentKey}/agent:${agent.id}`;
 
         rows.push({
           rank: agentLive || agent.state === "failed" ? 1 : 0,
-          text: `${stem} ${lastAgent ? "╰─" : "├─"} ${
+          parent: parentKey,
+          ...(kids.length > 0 ? { key: agentKey } : {}),
+          text: `${prefix}${lastAgent ? "╰─" : "├─"} ${
+
             silent === undefined
-              ? mark(agent.state, now)
-              : `${silent >= STALL_MS ? RED : AMBER}⚠${RESET}`
-          } ${agent.name}${
+              ? mark(agent.state, now, paint)
+              : paint(silent >= STALL_MS ? ROLE.failed : ROLE.warn, "⚠")
+          } ${
+            // The label is what the workflow called this agent — `reviewer #2`,
+            // `scout (api)` — where the name is the role it was built from. Two
+            // agents of one role are otherwise indistinguishable.
+            agent.label ?? agent.name
+          }${
             silent === undefined
               ? ""
-              : `${silent >= STALL_MS ? RED : AMBER}  ${
-                  silent >= STALL_MS ? "stalled" : "quiet"
-                } ${formatElapsed(silent)}${RESET}`
+              : `  ${paint(
+                  silent >= STALL_MS ? ROLE.failed : ROLE.warn,
+                  `${silent >= STALL_MS ? "stalled" : "quiet"} ${formatElapsed(silent)}`,
+                )}`
           }`,
           right: detail,
         });
+
+        kids.forEach((child, childIndex) => {
+          drawAgent(child, `${prefix}${lastAgent ? "   " : "  │"}`, childIndex === kids.length - 1, agentKey);
+        });
+      };
+
+      roots.forEach((agent, agentIndex) => {
+        drawAgent(agent, `${stem} `, agentIndex === roots.length - 1, phaseKey);
       });
     });
   }
 
-  const accent = BLUE;
+  // The rules change colour while scrolling, so it is obvious at a glance that
+  // the arrows are going here and not to the editor.
+  const accent = (text: string): string => paint(scrolling ? ROLE.warn : ROLE.live, text);
   const title = live.length === 1 ? "Workflow" : `Workflows · ${String(live.length)} runs`;
-  const body = collapse(rows, MAX_ROWS - 2);
+  sizeOut.rows = rows.length;
+  const body = collapse(rows, MAX_ROWS - 2, paint, offset, scrolling);
 
   // Width budget: the rule takes a column and a space on each side, so the
   // text has four fewer than the widget is given. Every piece is measured
   // against `inner` so the right-hand rule lands in one column on every row.
   const inner = Math.max(20, width - 4);
 
-  // The selected row is lit the way the rest of Pi lights a selection, from
-  // the active theme rather than a colour picked here — a widget that invented
-  // its own highlight would look wrong the moment the theme changed.
-  //
-  // The row is assembled from coloured pieces, each ending in a full reset, and
-  // a full reset clears the background along with the foreground. Painted
-  // naïvely, the highlight therefore survives only on the stretches with no
-  // colour in them — the indent and the tree stem — and dies behind every piece
-  // of text. Swapping the inner resets for a foreground-only reset keeps the
-  // background alive across the whole row.
-  const FG_RESET = "\u001b[39m";
-  const highlight = (text: string): string =>
-    theme ? theme.bg("selectedBg", text.replaceAll(RESET, FG_RESET)) : text;
 
-  // Side rules only, no lid and no floor.
-  //
-  // The box is not a thing in its own right — it is a margin note against the
-  // conversation, and two horizontal rules spend two of the few lines it is
-  // worth to say so. The title rides the first row instead, where it is read
-  // in the same glance as the run beneath it.
+  // Side rules below the lid, and no floor: the box opens downward into the
+  // editor rather than closing on itself, which is one more line kept for the
+  // run.
+  // A scrollbar on the right rule, drawn only when there is more tree than
+  // frame. Without it the window's position is a guess: three rows of a
+  // twenty-row tree look the same near the top as near the bottom.
+  const total = rows.length;
+  const shown = body.length;
+  const scrollbar = (index: number): string | undefined => {
+    if (!scrolling || total <= shown) return undefined;
+    // The thumb is positioned against how far the window can travel, not
+    // against the height of the tree. Dividing by the tree instead puts the
+    // thumb at the bottom while the window still has a row to give, which is
+    // the one thing a scrollbar must never say.
+    // The window shows `shown - 1` rows of the tree: the last line of the
+    // frame is the marker counting what is out of sight, which belongs to the
+    // scrollbar's question rather than to the tree it measures.
+    const visible = shown - 1;
+    const limit = maxOffset(total, MAX_ROWS - 2);
+    const start = Math.min(offset, limit);
+    // The thumb spans the visible share of the tree, at least one row, and
+    // never the whole track while rows remain out of sight.
+    const size = Math.min(shown - 1, Math.max(1, Math.round((visible / total) * shown)));
+    // Floor, not round: rounding up on the second-to-last step parks the thumb
+    // at the bottom while the window still has a row to travel. The bottom is
+    // reserved for the bottom, and reached only by landing on the limit.
+    const top = limit === 0 ? 0 : start >= limit ? shown - size : Math.floor((start / limit) * (shown - size));
+    return index >= top && index < top + size ? "█" : "░";
+  };
+
   const lines = body.map((row, index) => {
-    const selected = index === cursor;
     // The numbers hold the right edge; the name gives way when the two would
     // meet. A truncated workflow name is still recognisable, where a truncated
     // cost is a different number.
@@ -565,23 +738,37 @@ function renderFrame(runs: readonly Run[], now: number, width: number, cursor?: 
     const room = Math.max(0, inner - rightWidth);
     const left = visibleLength(row.text) > room ? truncate(row.text, room) : row.text;
     const gap = Math.max(0, inner - visibleLength(left) - (right === "" ? 0 : visibleLength(right)));
-    const text = right === "" ? left + " ".repeat(gap) : `${left}${" ".repeat(gap)}${DIM}${right}${RESET}`;
-    const rule = `${accent}│${RESET}`;
-    return selected ? `${rule}${highlight(` ${text} `)}${rule}` : `${rule} ${text} ${rule}`;
+    const text = right === "" ? left + " ".repeat(gap) : `${left}${" ".repeat(gap)}${paint(ROLE.quiet, right)}`;
+    const rule = accent("│");
+    const bar = scrollbar(index);
+    return `${rule} ${text} ${bar === undefined ? rule : accent(bar)}`;
   });
 
-  // The title carries the same colour as the rules it sits between: one mark
-  // in the margin, not a heading competing with the runs under it. The way in
-  // rides with it — a shortcut nobody can see is a shortcut nobody uses — and
-  // gives way to the title if the terminal is too narrow for both.
-  const hint = cursor === undefined ? `↓ or ${FOCUS_SHORTCUT}` : "↑↓ move · esc back";
-  const room = inner - visibleLength(title);
-  const withHint =
-    room >= visibleLength(hint) + 2
-      ? `${title}${" ".repeat(room - visibleLength(hint))}${hint}`
-      : `${title}${" ".repeat(Math.max(0, room))}`;
-  const heading = `${accent}│ ${withHint} │${RESET}`;
-  return [heading, ...lines];
+  // A lid that costs no line of its own.
+  //
+  // The title row carries the top rule through it — `╭─ Workflow ─── hint ─╮` —
+  // rather than sitting under a separate run of dashes. In ten rows a line
+  // spent on decoration is a line not spent on the run, and the box still
+  // reads as closed at the top.
+  // Nothing is promised while navigation is switched off: a hint for keys
+  // that do nothing is worse than no hint.
+  const hint = !__navigationForTests.enabled ? "" : scrolling ? "↑↓ scroll · esc to exit" : `${FOCUS_SHORTCUT} to scroll`;
+  const label = ` ${title} `;
+  const tail = hint === "" ? "" : ` ${hint} `;
+  const spare = inner + 2 - visibleLength(label) - visibleLength(tail);
+  const heading =
+    spare >= 2
+      ? accent(`╭${label}${"─".repeat(spare)}${tail}╮`)
+      : accent(`╭${label}${"─".repeat(Math.max(0, inner + 2 - visibleLength(label)))}╮`);
+  // A floor to close the box.
+  //
+  // Without it the side rules simply stop, and a frame that shrinks — a phase
+  // folded away, a run finished — leaves the tail of the taller one behind on
+  // screen, since Pi redraws differentially and the rows below are no longer
+  // its business. The closing rule gives the eye somewhere to stop and the
+  // redraw something to overwrite.
+  const foot = accent(`╰${"─".repeat(inner + 2)}╯`);
+  return [heading, ...lines, foot];
 }
 
 /** Everything worth keeping about a run once it is over. */
@@ -629,7 +816,9 @@ function receiptFor(run: Run): Receipt {
     agents: agents.map((agent, index) => {
       const calls = countToolCalls(run, index);
       return {
-        name: agent.name,
+        // What the workflow called it, falling back to the role it was built
+        // from. Two agents of one role are otherwise indistinguishable.
+        name: agent.label ?? agent.name,
         state: agent.state,
         // Model and thinking level together: a role picks both, and the model
         // name alone does not say whether it reasoned cheaply or deeply.
@@ -762,9 +951,13 @@ export default function widget(pi: ExtensionAPI): void {
    * time would be a widget you had to fight to write past.
    */
   let focused = false;
-  let cursor = 0;
   /** Rows in the last frame, so the cursor cannot leave it. */
   let rowCount = 0;
+  /** Keys of rows the reader has folded shut, kept across repaints. */
+  /** How far the window has been scrolled down the tree. */
+  let offset = 0;
+  /** Rows the tree had in the last frame, so scrolling cannot run off its end. */
+  const size = { rows: 0 };
   /**
    * The TUI the widget was last built against, kept only to ask whether
    * something else currently owns the keyboard.
@@ -857,11 +1050,18 @@ export default function widget(pi: ExtensionAPI): void {
         host = tui;
         return {
           render: (width: number): string[] => {
+            // The layout is composed against a floor of twenty columns, because
+            // a tree drawn narrower than that is unreadable anyway — but what
+            // leaves this function is measured against the width Pi actually
+            // gave. A pane narrower than the floor gets a cut frame; it does
+            // not get a crash, and pi-tui treats an over-wide line as fatal.
             const usable = Math.max(20, width);
-            const frame = renderFrame([...runs.values()], Date.now(), usable, focused ? cursor : undefined, theme) ?? [];
-            rowCount = frame.length - 1;
+            const frame = renderFrame([...runs.values()], Date.now(), usable, focused ? offset : 0, theme, focused, size) ?? [];
+            // The keys track the body rows exactly, so they say how far the
+            // cursor may travel — the lid and the floor are not rows to land on.
+            rowCount = size.rows;
             return frame.map((line) =>
-              visibleLength(line) > usable ? truncate(line, usable) : line,
+              visibleLength(line) > width ? truncate(line, width) : line,
             );
           },
           invalidate: (): void => {
@@ -936,6 +1136,13 @@ export default function widget(pi: ExtensionAPI): void {
     };
     if (!runId || !runDirectory || !eventSession) return;
     refresh(runId, runDirectory, eventSession);
+    // A run can end without a completed or failed event: stopping it, running
+    // it out of budget or losing it to an interrupt all arrive as a state
+    // change. Reading the state rather than the event name means every ending
+    // leaves a receipt — and an interrupted run is exactly the one whose cost
+    // is worth having a record of.
+    const run = runs.get(runId);
+    if (run && !isRunLive(run.state)) receipt(runId);
     tick();
   };
 
@@ -1005,6 +1212,16 @@ export default function widget(pi: ExtensionAPI): void {
 
     // Replay what the session already recorded so a reload cannot write the
     // same run into the transcript twice.
+    //
+    // The caches go with it. A reload may be entering a different session
+    // entirely, and runs left over from the last one would be drawn as though
+    // they were this session's; `seen` holds modification times that no longer
+    // describe anything, so a run whose file changed while the session was
+    // away would be judged unchanged and never re-read.
+    runs.clear();
+    seen.clear();
+    focused = false;
+    offset = 0;
     receipted.clear();
     try {
       for (const entry of sessionContext.sessionManager.getEntries()) {
@@ -1024,19 +1241,17 @@ export default function widget(pi: ExtensionAPI): void {
 
     // Keyboard access, taken as lightly as possible.
     //
-    // Keyboard access, taken as lightly as possible.
-    //
     // The handler sees every keystroke before the editor does, so it declines
-    // all but a few. `↓` on an empty editor is the natural way in — the same
-    // gesture Claude Code uses for its agent dock — but an empty editor is also
-    // what every picker and dialog leaves behind while it waits for arrows, so
-    // the key is only claimed once the TUI confirms nothing else is focused.
-    // The shortcut is the way in that never has to share.
-    unsubscribes.push(
-      sessionContext.ui.onTerminalInput((data: string) => {
-        if (!showing) return undefined;
+    // all but a few, and only while scrolling. `↓` on an empty editor would be
+    // the comfortable way in, but an empty editor is what every picker and
+    // dialog leaves behind while it waits for arrows — so the way in is the
+    // shortcut alone, which never has to share.
+    if (__navigationForTests.enabled) {
+      unsubscribes.push(
+        sessionContext.ui.onTerminalInput((data: string) => {
+          if (!showing) return undefined;
 
-        if (focused) {
+          if (focused) {
           // Something opened over the widget while it held the keyboard — a
           // command picker, a dialog. It has the better claim.
           if (somethingElseHasTheKeyboard()) {
@@ -1047,40 +1262,31 @@ export default function widget(pi: ExtensionAPI): void {
           // reach the editor, but do not move twice for one press.
           if (isKeyRelease(data)) return { consume: true };
           if (matchesKey(data, Key.up)) {
-            cursor = Math.max(0, cursor - 1);
+            offset = Math.max(0, offset - 1);
             return { consume: true };
           }
           if (matchesKey(data, Key.down)) {
-            cursor = Math.min(Math.max(0, rowCount - 1), cursor + 1);
+            // Stops where the window stops. Counting rows instead would let
+            // presses past the last row bank an offset nothing on screen can
+            // show, and every one of them would have to be paid back with an
+            // ↑ that appears to do nothing.
+            offset = Math.min(maxOffset(rowCount, MAX_ROWS - 2), offset + 1);
             return { consume: true };
           }
           if (matchesKey(data, Key.escape) || data === "q") {
+              focused = false;
+              return { consume: true };
+            }
+            // Anything else is someone typing: hand the keyboard back and let
+            // the keystroke through, so a thought is never lost to a panel.
             focused = false;
-            return { consume: true };
+            return undefined;
           }
-          // Anything else is someone typing: hand the keyboard back and let
-          // the keystroke through, so a thought is never lost to a panel.
-          focused = false;
-          return undefined;
-        }
 
-        if (isKeyRelease(data)) return undefined;
-        if (!matchesKey(data, Key.down)) return undefined;
-        // A menu is open, or focus has left the editor: the arrows are not
-        // ours to take.
-        if (somethingElseHasTheKeyboard()) return undefined;
-        let empty = false;
-        try {
-          empty = sessionContext.ui.getEditorText().trim() === "";
-        } catch {
-          // No editor to consult; leave the key alone.
-        }
-        if (!empty) return undefined;
-        focused = true;
-        cursor = 0;
-        return { consume: true };
-      }),
-    );
+          return undefined;
+        }),
+      );
+    }
 
     tick();
   });
@@ -1088,12 +1294,12 @@ export default function widget(pi: ExtensionAPI): void {
   // A way in that never competes. `↓` is the comfortable gesture but it is
   // shared with every picker; the shortcut answers whatever else is on screen,
   // and Pi lets it be rebound in `keybindings.json` like any other.
-  pi.registerShortcut(FOCUS_SHORTCUT, {
-    description: "Focus the workflow widget",
+  if (__navigationForTests.enabled) pi.registerShortcut(FOCUS_SHORTCUT, {
+    description: "Scroll the workflow widget",
     handler: () => {
       if (!showing) return;
       focused = !focused;
-      cursor = 0;
+      offset = 0;
     },
   });
 

--- a/packages/extensions/widget/package.json
+++ b/packages/extensions/widget/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@piewf/widget",
+  "version": "5.2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "test": "npm run build && node --test --test-timeout=30000 --test-force-exit test/index.test.mjs",
+    "prepack": "npm run build",
+    "lint": "eslint ."
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "pi-extensible-workflows": "*",
+    "@earendil-works/pi-tui": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vekexasia/pi-extensible-workflows.git",
+    "directory": "packages/extensions/widget"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./index.js": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.82.1",
+    "@types/node": "24.12.4",
+    "typescript": "5.9.3",
+    "@earendil-works/pi-tui": "*"
+  }
+}

--- a/packages/extensions/widget/test/index.test.mjs
+++ b/packages/extensions/widget/test/index.test.mjs
@@ -1,0 +1,827 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import widget, { renderReceipt } from "../dist/index.js";
+import {
+  WORKFLOW_AGENT_STATE_CHANGED_EVENT,
+  WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT,
+  WORKFLOW_RUN_COMPLETED_EVENT,
+  WORKFLOW_RUN_STARTED_EVENT,
+  WORKFLOW_RUN_STATE_CHANGED_EVENT,
+} from "pi-extensible-workflows";
+
+// Stands in for Pi's theme. `bg` wraps rather than colours so a test can see
+// which row was highlighted without matching escape codes.
+const theme = {
+  fg: (_colour, text) => text,
+  bold: (text) => text,
+  bg: (_colour, text) => `\u0001${text}\u0001`,
+};
+
+/** Width the harness renders at, standing in for the terminal. */
+const WIDTH = 78;
+
+/** Strips ANSI colour codes so assertions read against plain text. */
+// eslint-disable-next-line no-control-regex
+const plain = (line) => line.replace(/\x1b\[[0-9;]*m/g, "");
+
+function writeRun(directory, state) {
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, "state.json"), JSON.stringify(state));
+  return directory;
+}
+
+function runState(overrides = {}) {
+  return {
+    id: "run-1",
+    workflowName: "smoke",
+    sessionId: "session-1",
+    state: "running",
+    phase: "llm",
+    phaseHistory: [{ phase: "shell", afterAgent: 0 }, { phase: "llm", afterAgent: 0 }],
+    agents: [{
+      name: "scout",
+      role: "scout",
+      requestedModel: "scout-model",
+      state: "running",
+      startedAt: Date.now() - 42_000,
+      tools: ["read", "grep"],
+      model: { model: "fixture-model", thinking: "medium" },
+      accounting: { input: 44_000, output: 700, cacheRead: 200_000, cost: 0.056 },
+    }],
+    usage: { tokens: 44_700, costUsd: 0.056 },
+    ...overrides,
+  };
+}
+
+/** A stand-in for the extension host, capturing everything the widget draws. */
+function harness(sessionId = "session-1") {
+  const handlers = new Map();
+  const events = new Map();
+  const frames = [];
+  const widgets = [];
+  const entries = [];
+  const placements = [];
+  const shortcuts = new Map();
+  // Stands in for Pi's TUI. At rest the editor holds focus; a picker moves it
+  // and an overlay is flagged outright.
+  // Recognised by what it can do, not by its class: a widget installed beside
+  // Pi may hold a second copy of the TUI package, and `instanceof` then fails
+  // for the very editor it is asked about.
+  const editor = { getText: () => "", addToHistory: () => {} };
+  const tui = {
+    hasOverlay: () => tui.overlay,
+    getFocusedComponent: () => tui.focus,
+    overlay: false,
+    focus: editor,
+    openMenu: () => { tui.focus = { name: "picker" }; },
+    closeMenu: () => { tui.focus = editor; },
+  };
+  const inputHandlers = [];
+  let editorText = "";
+  let renderer;
+
+  const pi = {
+    on: (name, handler) => { handlers.set(name, handler); },
+    events: {
+      on: (name, handler) => {
+        events.set(name, [...(events.get(name) ?? []), handler]);
+        return () => { events.set(name, (events.get(name) ?? []).filter((h) => h !== handler)); };
+      },
+    },
+    appendEntry: (customType, data) => { entries.push({ customType, data }); },
+    registerEntryRenderer: (customType, fn) => { renderer = { customType, fn }; },
+    registerShortcut: (shortcut, options) => { shortcuts.set(shortcut, options); },
+  };
+
+  const context = {
+    hasUI: true,
+    sessionManager: { getSessionId: () => sessionId, getEntries: () => [] },
+    // The widget registers a factory so it is built at the width the TUI is
+    // about to draw with. Render it the way the host does, at a fixed width.
+    ui: {
+      setWidget: (_key, value, options) => {
+        widgets.push(value);
+        placements.push(options?.placement);
+        frames.push(typeof value === "function" ? value(tui, theme).render(WIDTH) : value);
+      },
+      onTerminalInput: (handler) => {
+        inputHandlers.push(handler);
+        return () => { inputHandlers.splice(inputHandlers.indexOf(handler), 1); };
+      },
+      getEditorText: () => editorText,
+    },
+  };
+
+  widget(pi);
+  return {
+    context,
+    frames,
+    widgets,
+    placements,
+    entries,
+    tui,
+    shortcuts,
+    setEditorText: (text) => { editorText = text; },
+    // Feed a keystroke the way the host does: every handler sees it until one
+    // claims it.
+    key: (data) => {
+      for (const handler of inputHandlers) {
+        const result = handler(data);
+        if (result?.consume) return true;
+      }
+      return false;
+    },
+    get renderer() { return renderer; },
+    start: () => handlers.get("session_start")(undefined, context),
+    shutdown: () => handlers.get("session_shutdown")(undefined, context),
+    emit: (name, event) => { for (const handler of events.get(name) ?? []) handler(event); },
+  };
+}
+
+void test("draws a tree for a live run and clears it once the run is over", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-live-"));
+  const directory = writeRun(join(root, "run-1"), runState());
+  const host = harness();
+  host.start();
+
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  const frame = host.frames.at(-1);
+  assert.ok(Array.isArray(frame), "a live run is drawn");
+  const body = frame.map(plain).join("\n");
+  assert.match(body, /smoke/);
+  assert.match(body, /shell/);
+  assert.match(body, /scout/);
+  assert.match(body, /fixture-model:medium/);
+
+  writeRun(directory, runState({ state: "completed", agents: [] }));
+  host.emit(WORKFLOW_AGENT_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  assert.equal(host.frames.at(-1), undefined, "a finished run leaves the widget at once");
+
+  host.shutdown();
+});
+
+void test("ignores runs belonging to another session", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-scope-"));
+  const directory = writeRun(join(root, "run-1"), runState({ sessionId: "other" }));
+  const host = harness("session-1");
+  host.start();
+
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "other" });
+  assert.ok(host.frames.every((frame) => frame === undefined), "another session's run is not drawn");
+
+  host.shutdown();
+});
+
+void test("writes one receipt per run, however many events arrive", async () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-receipt-"));
+  const directory = writeRun(join(root, "run-1"), runState({
+    state: "completed",
+    agents: [{ ...runState().agents[0], state: "completed", durationMs: 62_000 }],
+    usage: { tokens: 61_229, costUsd: 0.0857, durationMs: 82_529 },
+  }));
+  const host = harness();
+  host.start();
+
+  host.emit(WORKFLOW_RUN_COMPLETED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  host.emit(WORKFLOW_RUN_COMPLETED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 250));
+
+  assert.equal(host.entries.length, 1, "the run is recorded once");
+  assert.equal(host.entries[0].data.runId, "run-1");
+  assert.equal(host.entries[0].data.tokens, 61_229);
+  assert.equal(host.entries[0].data.agents[0].cacheRead, 200_000);
+
+  host.shutdown();
+});
+
+void test("the receipt shows phases, per-agent models, effort and the token split", () => {
+  const lines = renderReceipt({
+    runId: "run-1",
+    workflow: "deliver",
+    state: "failed",
+    costUsd: 0.4,
+    tokens: 128_000,
+    durationMs: 96_000,
+    phases: ["scout", "review"],
+    phaseBoundaries: [0, 1],
+    agents: [
+      { name: "scout", state: "completed", model: "fixture-model:high", role: "scout", requestedModel: "scout-model", toolCalls: 31, input: 30_000, output: 900, cacheRead: 80_000, costUsd: 0.09, durationMs: 31_000, attempts: 1 },
+      { name: "reviewer", state: "failed", model: "fixture-model:xhigh", role: "reviewer", toolCalls: 1, input: 50_000, output: 200, cacheRead: 120_000, costUsd: 0.31, durationMs: 15_000, attempts: 3 },
+    ],
+    error: "reviewer was interrupted before it answered",
+  }, false, theme);
+
+  const body = lines.join("\n");
+  assert.match(body, /deliver/);
+  assert.match(body, /scout/);
+  assert.match(body, /review/);
+  assert.match(body, /role scout · via scout-model · 31 calls/);
+  assert.match(body, /role reviewer · 1 call/, "one call is not pluralised");
+  assert.match(body, /in 30kt · out 900t · cache 80kt/);
+  assert.match(body, /3 attempts/, "a retried agent says so");
+  assert.match(body, /interrupted before it answered/);
+  assert.doesNotMatch(body, /run-1/, "the run id stays hidden until expanded");
+
+  assert.match(renderReceipt({
+    runId: "run-1", workflow: "smoke", state: "completed", costUsd: 0, tokens: 0, durationMs: 0,
+    phases: [], phaseBoundaries: [], agents: [],
+  }, true, theme).join("\n"), /run run-1/);
+});
+
+void test("the border lines up at every width the TUI asks for", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-width-"));
+  const directory = writeRun(join(root, "run-1"), runState());
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  const factory = host.widgets.at(-1);
+  assert.equal(typeof factory, "function", "the widget is registered as a factory");
+
+  // The frame is built at whatever width the TUI is about to draw with, which
+  // is the only number that agrees with the check Pi runs on the result.
+  const component = factory();
+  for (const width of [40, 60, 81, 110, 165]) {
+    const widths = new Set(component.render(width).map((line) => plain(line).length));
+    assert.deepEqual([...widths], [width], `a ${width}-column draw produces ${width}-wide rows`);
+  }
+
+  host.shutdown();
+});
+
+
+void test("a second instance starting and stopping leaves the first one working", async () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-coexist-"));
+  const directory = writeRun(join(root, "run-1"), runState({
+    state: "completed",
+    agents: [{ ...runState().agents[0], state: "completed", durationMs: 1_000 }],
+    usage: { tokens: 100, costUsd: 0.01, durationMs: 1_000 },
+  }));
+
+  // An agent pane boots its own extension host inside the same process: a
+  // second instance loads, runs a whole session, and shuts down again while
+  // the first one is still driving the visible widget.
+  const bus = new Map();
+  const entries = [];
+  const load = () => {
+    const handlers = new Map();
+    widget({
+      on: (name, handler) => { handlers.set(name, handler); },
+      events: {
+        on: (name, handler) => {
+          bus.set(name, [...(bus.get(name) ?? []), handler]);
+          return () => { bus.set(name, (bus.get(name) ?? []).filter((h) => h !== handler)); };
+        },
+      },
+      appendEntry: (customType, data) => { entries.push({ customType, data }); },
+      registerEntryRenderer: () => {},
+      registerShortcut: () => {},
+    });
+    handlers.get("session_start")(undefined, {
+      hasUI: true,
+      sessionManager: { getSessionId: () => "session-1", getEntries: () => [] },
+      ui: { setWidget: () => {}, onTerminalInput: () => () => {}, getEditorText: () => "" },
+    });
+    return handlers;
+  };
+
+  load();
+  const pane = load();
+  // The pane closes; the session that owns the widget is still open.
+  pane.get("session_shutdown")(undefined, undefined);
+
+  for (const handler of bus.get(WORKFLOW_RUN_COMPLETED_EVENT) ?? []) {
+    handler({ runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  }
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 250));
+
+  assert.equal(entries.length, 1, "the surviving instance still writes its receipt");
+});
+
+
+void test("a quiet agent is flagged early, a stalled one more loudly", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-stall-"));
+  const state = runState();
+  const host = harness();
+  host.start();
+
+  // Four minutes of silence: too long to be thinking, and the signature of an
+  // agent asking a question in its own pane — which the core cannot see.
+  // Both the run state and the transcript are stale: nothing has moved.
+  const oldTranscript = join(root, "old.jsonl");
+  writeFileSync(oldTranscript, "{}\n");
+  utimesSync(oldTranscript, new Date(Date.now() - 4 * 60_000), new Date(Date.now() - 4 * 60_000));
+  const sessions = [{ transport: "local", sessionId: "s", locator: { sessionFile: oldTranscript } }];
+
+  const quiet = writeRun(join(root, "run-1"), {
+    ...state,
+    agentSessions: sessions,
+    agents: [{ ...state.agents[0], lastEventAt: Date.now() - 4 * 60_000 }],
+  });
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: quiet, sessionId: "session-1" });
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /quiet 04:0\d/, "the silence is shown with its length");
+
+  // Past the core's own stall threshold it stops being merely quiet.
+  const deadTranscript = join(root, "dead.jsonl");
+  writeFileSync(deadTranscript, "{}\n");
+  utimesSync(deadTranscript, new Date(Date.now() - 11 * 60_000), new Date(Date.now() - 11 * 60_000));
+
+  const stalled = writeRun(join(root, "run-2"), {
+    ...state,
+    agentSessions: [{ transport: "local", sessionId: "s2", locator: { sessionFile: deadTranscript } }],
+    agents: [{ ...state.agents[0], lastEventAt: Date.now() - 11 * 60_000 }],
+  });
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-2", runDirectory: stalled, sessionId: "session-1" });
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /stalled 11:0\d/, "a stalled agent says so");
+
+  host.shutdown();
+});
+
+void test("a retry is visible while it is happening, not only in the receipt", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-retry-"));
+  const state = runState();
+  const directory = writeRun(join(root, "run-1"), {
+    ...state,
+    agents: [{ ...state.agents[0], attempts: 2 }],
+  });
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /attempt 2/, "the attempt count is shown");
+
+  host.shutdown();
+});
+
+void test("a phase of shell work shows its commands once they have run a while", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-shell-"));
+  const state = runState();
+  const base = { ...state, agents: [] };
+  const host = harness();
+  host.start();
+
+  // A command that just started stays quiet; the phase would otherwise flicker.
+  const brief = writeRun(join(root, "run-1"), {
+    ...base,
+    activeShellsByPhase: [{ phaseIndex: 0, active: 1, startedAt: Date.now() - 500 }],
+  });
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: brief, sessionId: "session-1" });
+  assert.doesNotMatch(host.frames.at(-1).map(plain).join("\n"), /command/, "a brief command is not worth a row");
+
+  const settled = writeRun(join(root, "run-2"), {
+    ...base,
+    activeShellsByPhase: [{ phaseIndex: 0, active: 2, startedAt: Date.now() - 20_000 }],
+  });
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-2", runDirectory: settled, sessionId: "session-1" });
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /2 commands/, "a long-running phase says how many");
+
+  host.shutdown();
+});
+
+void test("crossing a budget threshold shows on the run line", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-budget-"));
+  const directory = writeRun(join(root, "run-1"), {
+    ...runState(),
+    budgetEvents: [{ type: "soft_crossed", dimensions: ["costUsd"] }],
+  });
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /near budget \(costUsd\)/, "the crossed dimension is named");
+
+  host.shutdown();
+});
+
+void test("a checkpoint waiting on a person is shown, and clears when answered", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-checkpoint-"));
+  const directory = writeRun(join(root, "run-1"), runState());
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, { runId: "run-1", name: "merge the MR?", state: "awaiting" });
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /waiting: merge the MR\?/, "the question is shown");
+
+  // A re-read of the state file must not lose it: disk knows nothing of checkpoints.
+  host.emit(WORKFLOW_RUN_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /waiting: merge the MR\?/, "it survives a state re-read");
+
+  host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, { runId: "run-1", name: "merge the MR?", state: "approved" });
+  assert.doesNotMatch(host.frames.at(-1).map(plain).join("\n"), /waiting/, "answering clears it");
+
+  host.shutdown();
+});
+
+void test("the receipt counts what an agent did, not what it was allowed to do", () => {
+  // The permitted toolbox is a property of the role, identical on every run
+  // that uses it, and an agent with no role inherits sixty-odd names that say
+  // nothing while pushing the rest of the receipt off the screen. The number
+  // of calls is what differs from run to run.
+  const lines = renderReceipt(
+    {
+      runId: "run-1",
+      workflow: "gate",
+      state: "completed",
+      tokens: 100,
+      costUsd: 0.01,
+      durationMs: 1_000,
+      phases: ["after"],
+      phaseBoundaries: [0],
+      agents: [{ name: "scout", state: "completed", toolCalls: 31, input: 10, output: 5, cacheRead: 0, costUsd: 0.01, durationMs: 1_000, attempts: 1 }],
+    },
+    false,
+    theme,
+  ).map(plain);
+
+  const body = lines.join("\n");
+  assert.match(body, /31 calls/, "the effort is reported");
+  assert.doesNotMatch(body, /tool0|read grep/, "the toolbox is not listed");
+});
+
+void test("shell activity appears without an event to announce it", async () => {
+  // A phase running nothing but shell commands produces no events at all: the
+  // core writes activeShells into the state file quietly. Without noticing that
+  // the file changed, such a phase sits on screen looking like nothing happens.
+  const root = mkdtempSync(join(tmpdir(), "widget-rescan-"));
+  const directory = join(root, "run-1");
+  const base = {
+    ...runState(),
+    agents: [],
+    phaseHistory: [{ phase: "build", afterAgent: 0 }],
+  };
+  writeRun(directory, base);
+
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  assert.doesNotMatch(host.frames.at(-1).map(plain).join("\n"), /command/, "nothing to report yet");
+
+  // The shell has now been running a while, and only the file says so.
+  writeRun(directory, {
+    ...base,
+    activeShellsByPhase: [{ phaseIndex: 0, active: 1, startedAt: Date.now() - 30_000 }],
+  });
+
+  // Wait past one repaint without emitting anything.
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 400));
+
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /1 command/, "the widget noticed on its own");
+
+  host.shutdown();
+});
+
+void test("a busy agent is not called quiet just because the run state is stale", () => {
+  // The run state's lastEventAt is written only when the core persists, so a
+  // perfectly busy agent can look silent for minutes. The agent's transcript is
+  // appended to on every turn — that is the signal that it is alive.
+  const root = mkdtempSync(join(tmpdir(), "widget-busy-"));
+  const transcript = join(root, "agent.jsonl");
+  writeFileSync(transcript, "{}\n");
+
+  const state = runState();
+  const stale = {
+    ...state,
+    agentSessions: [{ transport: "local", sessionId: "s", locator: { sessionFile: transcript } }],
+    agents: [{ ...state.agents[0], lastEventAt: Date.now() - 8 * 60_000 }],
+  };
+  const directory = writeRun(join(root, "run-1"), stale);
+
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  assert.doesNotMatch(
+    host.frames.at(-1).map(plain).join("\n"),
+    /quiet|stalled/,
+    "a transcript written moments ago outweighs a stale run state",
+  );
+
+  host.shutdown();
+});
+
+void test("a busy screen still produces a frame Pi will not truncate", () => {
+  // Pi cuts a widget at MAX_WIDGET_LINES (10) and appends its own notice. A
+  // frame cut there loses its closing border, the box never closes, and the
+  // leftovers pile up — which is what several concurrent runs used to do.
+  const root = mkdtempSync(join(tmpdir(), "widget-busy-screen-"));
+  const host = harness();
+  host.start();
+
+  const agent = (name, state) => ({
+    name,
+    role: "ops",
+    state,
+    startedAt: Date.now() - 60_000,
+    tools: ["read"],
+    model: { model: "fixture-model", thinking: "low" },
+    accounting: { input: 1_000, output: 10, cacheRead: 0, cacheWrite: 0, cost: 0.01 },
+  });
+
+  // Two runs, each several phases deep: eleven rows before folding.
+  for (const [index, id] of ["run-1", "run-2"].entries()) {
+    const directory = writeRun(join(root, id), {
+      ...runState(),
+      id,
+      workflowName: `flow-${String(index)}`,
+      phaseHistory: [
+        { phase: "worktree", afterAgent: 0 },
+        { phase: "discover", afterAgent: 0 },
+        { phase: "plan", afterAgent: 1 },
+      ],
+      agents: [agent("scout", "completed"), agent("planner", "running")],
+    });
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: id, runDirectory: directory, sessionId: "session-1" });
+  }
+
+  const frame = host.frames.at(-1);
+  assert.ok(frame.length <= 20, `the frame stays within its row budget, got ${frame.length}`);
+  // Side rules only: no lid, no floor. Every row carries one on each edge.
+  for (const line of frame) assert.match(plain(line), /^│.*│$/, `a rule on both edges, got: ${plain(line)}`);
+
+  // Folding must not hide the work that is actually happening.
+  const text = frame.map(plain).join("\n");
+  assert.match(text, /planner/, "a running agent survives the fold");
+
+  host.shutdown();
+});
+
+void test("a receipt line longer than the terminal is cut, not fatal", () => {
+  // Taken from a real crash: a role with ten tools produced a 110-column line
+  // in a 72-column terminal. Pi treats an over-wide line as fatal rather than
+  // wrapping it, so the session died drawing its own receipt.
+  const host = harness();
+  host.start();
+
+  const component = host.renderer.fn(
+    {
+      data: {
+        runId: "run-1",
+        workflowName: "act-document",
+        state: "completed",
+        tokens: 131_000,
+        cost: 1.62,
+        durationMs: 899_000,
+        phases: [{ name: "plan", state: "completed" }],
+        phaseBoundaries: [0],
+        agents: [{
+          name: "planner-deep",
+          state: "completed",
+          model: "claude-opus-5:xhigh",
+          role: "planner-deep",
+          requestedModel: "planner-model",
+          tools: ["read", "grep", "find", "ls", "symbol_search", "module_report", "read_symbol", "bash"],
+          input: 28,
+          output: 17_000,
+          cacheRead: 875_000,
+          cost: 1.4,
+          durationMs: 457_000,
+          attempts: 1,
+        }],
+      },
+    },
+    { expanded: false },
+    theme,
+  );
+
+  for (const width of [40, 72, 110]) {
+    const tooWide = component.render(width).filter((line) => plain(line).length > width);
+    assert.deepEqual(tooWide, [], `nothing exceeds ${width} columns`);
+  }
+
+  host.shutdown();
+});
+
+void test("a foreground run is left to the workflow tool that is already drawing it", () => {
+  // A foreground run is rendered by the tool call that waited for it, in more
+  // detail than the run state on disk allows — it has the live activity and
+  // token counts that are never persisted. Drawing it again here would be two
+  // views of one run, disagreeing.
+  const root = mkdtempSync(join(tmpdir(), "widget-foreground-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), {
+    ...runState(),
+    delivery: { mode: "foreground", state: "attached" },
+  });
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  assert.equal(host.frames.at(-1), undefined, "no widget for a foreground run");
+
+  host.shutdown();
+});
+
+void test("a foreground run leaves no receipt either", async () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-foreground-receipt-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), {
+    ...runState(),
+    state: "completed",
+    delivery: { mode: "foreground", state: "delivered" },
+    agents: [{ ...runState().agents[0], state: "completed", durationMs: 1_000 }],
+  });
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  host.emit(WORKFLOW_RUN_COMPLETED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 250));
+
+  assert.deepEqual(host.entries, [], "the tool call already summarised it");
+
+  host.shutdown();
+});
+
+
+void test("the widget sits below the editor and walks its rows on ↓", () => {
+  // Focus is taken only from an empty editor, on the one key that has nothing
+  // else to do there, and handed back the moment anything is typed. A widget
+  // that held the keyboard any longer would be one you had to fight past.
+  const root = mkdtempSync(join(tmpdir(), "widget-focus-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), {
+    ...runState(),
+    phaseHistory: [{ phase: "discover", afterAgent: 0 }, { phase: "plan", afterAgent: 1 }],
+    agents: [
+      { ...runState().agents[0], state: "completed" },
+      { ...runState().agents[0], id: "a2", name: "planner", state: "running" },
+    ],
+  });
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  assert.equal(host.placements.at(-1), "belowEditor", "below the editor, not above it");
+
+  // Captured from a live session: with the kitty keyboard protocol, which Pi
+  // negotiates, an arrow arrives parameterised rather than as a bare `\x1b[B`.
+  // `:1` is the press, `:3` its release, and `:2` the repeat while held — the
+  // counts in that capture came in `:1`/`:3` pairs with a long `:2` run.
+  const DOWN = "\u001b[1;1:1B";
+  const DOWN_RELEASE = "\u001b[1;1:3B";
+  const DOWN_REPEAT = "\u001b[1;1:2B";
+  const UP = "\u001b[1;1:1A";
+  const ESC = "\u001b";
+
+  // With text in the editor, ↓ belongs to the editor.
+  host.setEditorText("some text");
+  assert.equal(host.key(DOWN), false, "a keystroke meant for the editor is left alone");
+
+  host.setEditorText("");
+  assert.equal(host.key(DOWN), true, "↓ on an empty editor takes focus");
+  assert.equal(host.key(DOWN_RELEASE), true, "the release half is swallowed, not acted on");
+  assert.equal(host.key(DOWN), true, "and moves down");
+  assert.equal(host.key(DOWN_REPEAT), true, "holding the key keeps moving");
+  assert.equal(host.key(UP), true, "and back up");
+
+  // The bare form still works where a terminal speaks the older protocol.
+  assert.equal(host.key("\u001b[B"), true, "the unparameterised arrow is understood too");
+
+  const rendered = host.widgets.at(-1)(host.tui, theme).render(WIDTH);
+  const selected = rendered.filter((line) => line.includes("\u0001"));
+  assert.equal(selected.length, 1, "exactly one row is lit");
+
+  assert.equal(host.key(ESC), true, "escape gives the keyboard back");
+  assert.equal(host.key("x"), false, "and typing reaches the editor again");
+
+  host.shutdown();
+});
+
+void test("the highlight covers the whole selected row, text included", () => {
+  // A row is assembled from coloured pieces, each ending in a full reset, and
+  // a full reset clears the background too. Painted without care the highlight
+  // survives only on the indent and the tree stem, and dies behind every piece
+  // of text — a stripe rather than a selection.
+  const root = mkdtempSync(join(tmpdir(), "widget-highlight-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), runState());
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  host.setEditorText("");
+  // Down onto the run header, which carries the dimmed figures on its right.
+  host.key("\u001b[1;1:1B");
+  host.key("\u001b[1;1:1B");
+
+  const lit = host.widgets.at(-1)(host.tui, theme).render(WIDTH).find((line) => line.includes("\u0001"));
+  assert.ok(lit, "a row is lit");
+
+  // Between the markers the background must never be cancelled: a full reset
+  // in there is exactly the bug.
+  const inside = lit.slice(lit.indexOf("\u0001") + 1, lit.indexOf("\u0001", lit.indexOf("\u0001") + 1));
+  assert.ok(!inside.includes("\u001b[0m"), `no full reset inside the highlight, got: ${JSON.stringify(inside)}`);
+  assert.ok(inside.includes("\u001b[39m"), "colours are still ended, just without clearing the background");
+
+  host.shutdown();
+});
+
+void test("an open menu keeps the arrow keys", () => {
+  // Every command picker leaves the editor empty while it waits for ↑/↓ —
+  // precisely the condition this widget uses to claim the key. Claiming it
+  // anyway meant `/workflow` opened a menu you could not move through.
+  const root = mkdtempSync(join(tmpdir(), "widget-menu-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), runState());
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  const DOWN = "\u001b[1;1:1B";
+  host.setEditorText("");
+
+  host.tui.openMenu();
+  assert.equal(host.key(DOWN), false, "the menu keeps ↓");
+
+  host.tui.closeMenu();
+  assert.equal(host.key(DOWN), true, "and the widget takes it once the menu is gone");
+
+  // A menu opening while the widget is focused takes the keyboard back.
+  host.tui.openMenu();
+  assert.equal(host.key(DOWN), false, "a menu opening over the widget wins");
+
+  // An overlay counts the same way.
+  host.tui.closeMenu();
+  host.tui.overlay = true;
+  assert.equal(host.key(DOWN), false, "an overlay keeps the keys too");
+
+  host.shutdown();
+});
+
+void test("the shortcut focuses the widget when the arrow cannot", () => {
+  // `↓` has to defer to anything else on screen, so there has to be a way in
+  // that does not — otherwise the widget is unreachable exactly when a menu
+  // happens to be open. Registering it through Pi also means it can be rebound
+  // in keybindings.json.
+  const root = mkdtempSync(join(tmpdir(), "widget-shortcut-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), runState());
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  const shortcut = [...host.shortcuts.values()][0];
+  assert.ok(shortcut, "a shortcut is registered");
+
+  shortcut.handler();
+  const lit = host.widgets.at(-1)(host.tui, theme).render(WIDTH).filter((line) => line.includes("\u0001"));
+  assert.equal(lit.length, 1, "the shortcut lights a row");
+
+  shortcut.handler();
+  const dark = host.widgets.at(-1)(host.tui, theme).render(WIDTH).filter((line) => line.includes("\u0001"));
+  assert.equal(dark.length, 0, "and pressing it again gives the keyboard back");
+
+  host.shutdown();
+});
+
+void test("the title row says how to get in", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-hint-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), runState());
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  assert.match(plain(host.frames.at(-1)[0]), /↓ or alt\+o/, "the way in is on the title row");
+
+  host.setEditorText("");
+  host.key("\u001b[1;1:1B");
+  const inside = host.widgets.at(-1)(host.tui, theme).render(WIDTH);
+  assert.match(plain(inside[0]), /↑↓ move · esc back/, "and the keys change once inside");
+
+  host.shutdown();
+});
+
+void test("focus is recognised across a duplicated TUI package", () => {
+  // npm may install a second copy of the TUI package beside the widget, so the
+  // editor Pi hands over is an instance of a *different* Editor class than any
+  // the widget could import. An identity check answers "not an editor" for the
+  // editor itself, and the widget then believes a menu is permanently open:
+  // `↓` stops working and the shortcut lights a row that vanishes on the next
+  // keystroke. Recognition by capability is immune to it.
+  const root = mkdtempSync(join(tmpdir(), "widget-dup-tui-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), runState());
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  // An editor from a foreign copy of the package: same shape, unrelated class.
+  class ForeignEditor {
+    getText() { return ""; }
+    addToHistory() { /* nothing */ }
+  }
+  host.tui.focus = new ForeignEditor();
+
+  host.setEditorText("");
+  assert.equal(host.key("\u001b[1;1:1B"), true, "↓ still works with a foreign editor focused");
+
+  const lit = host.widgets.at(-1)(host.tui, theme).render(WIDTH).filter((line) => line.includes("\u0001"));
+  assert.equal(lit.length, 1, "and the row stays lit");
+
+  host.shutdown();
+});

--- a/packages/extensions/widget/test/index.test.mjs
+++ b/packages/extensions/widget/test/index.test.mjs
@@ -1,14 +1,16 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import widget, { renderReceipt, __navigationForTests } from "../dist/index.js";
+import { RunStore } from "pi-extensible-workflows/persistence";
 import {
   WORKFLOW_AGENT_STATE_CHANGED_EVENT,
   WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT,
   WORKFLOW_RUN_COMPLETED_EVENT,
+  WORKFLOW_RUN_FAILED_EVENT,
   WORKFLOW_RUN_STARTED_EVENT,
   WORKFLOW_RUN_STATE_CHANGED_EVENT,
 } from "pi-extensible-workflows";
@@ -60,7 +62,8 @@ function runState(overrides = {}) {
 }
 
 /** A stand-in for the extension host, capturing everything the widget draws. */
-function harness(sessionId = "session-1") {
+function harness(sessionId = "session-1", options = {}) {
+  let sessionEntries = options.entries ?? [];
   const handlers = new Map();
   const events = new Map();
   const frames = [];
@@ -101,7 +104,8 @@ function harness(sessionId = "session-1") {
 
   const context = {
     hasUI: true,
-    sessionManager: { getSessionId: () => sessionId, getEntries: () => [] },
+    cwd: options.cwd,
+    sessionManager: { getSessionId: () => sessionId, getEntries: () => sessionEntries },
     // The widget registers a factory so it is built at the width the TUI is
     // about to draw with. Render it the way the host does, at a fixed width.
     ui: {
@@ -138,6 +142,8 @@ function harness(sessionId = "session-1") {
       return false;
     },
     get renderer() { return renderer; },
+    setEntries: (entries) => { sessionEntries = entries; },
+    reload: () => handlers.get("session_start")(undefined, context),
     start: () => handlers.get("session_start")(undefined, context),
     shutdown: () => handlers.get("session_shutdown")(undefined, context),
     emit: (name, event) => { for (const handler of events.get(name) ?? []) handler(event); },
@@ -164,6 +170,83 @@ void test("draws a tree for a live run and clears it once the run is over", () =
   host.emit(WORKFLOW_AGENT_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
   assert.equal(host.frames.at(-1), undefined, "a finished run leaves the widget at once");
 
+  host.shutdown();
+});
+
+void test("isolates malformed state from healthy runs", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-malformed-state-"));
+  const healthy = writeRun(join(root, "healthy"), runState({ id: "healthy", workflowName: "healthy" }));
+  const malformed = writeRun(join(root, "malformed"), runState({ id: "malformed", workflowName: "malformed", agents: [null] }));
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "healthy", runDirectory: healthy, sessionId: "session-1" });
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "malformed", runDirectory: malformed, sessionId: "session-1" });
+
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /healthy/);
+  assert.doesNotMatch(host.frames.at(-1).map(plain).join("\n"), /malformed/);
+  host.shutdown();
+});
+
+void test("paused and resumable run states use non-running glyphs", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-status-glyphs-"));
+  const host = harness();
+  host.start();
+  for (const state of ["paused", "awaiting_input", "interrupted", "budget_exhausted"]) {
+    const directory = writeRun(join(root, state), runState({ id: state, workflowName: state, state }));
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: state, runDirectory: directory, sessionId: "session-1" });
+    const header = host.frames.at(-1).map(plain).find((line) => line.includes(` ${state} `));
+    assert.ok(header);
+    const expected = state === "budget_exhausted" ? "✗" : "·";
+    assert.match(header, new RegExp(`${expected} ${state} `), `${state} is not active`);
+    assert.doesNotMatch(header, /[⣷⣯⣟⡿⢿⣽⣻]/, `${state} does not spin`);
+  }
+
+  const budgetHeader = host.frames.at(-1).map(plain).find((line) => line.includes(" budget_exhausted "));
+  assert.match(budgetHeader, /✗ budget_exhausted /);
+  host.shutdown();
+});
+
+void test("live per-agent totals exclude cache-write tokens", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-token-total-"));
+  const directory = writeRun(join(root, "run-1"), runState({
+    agents: [{ ...runState().agents[0], accounting: { input: 10, output: 5, cacheRead: 20, cacheWrite: 10_000, cost: 0.01 } }],
+    usage: { tokens: 15, costUsd: 0.01 },
+  }));
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  const body = host.frames.at(-1).map(plain).join("\n");
+  assert.match(body, /fixture-model:medium · 15t/);
+  assert.doesNotMatch(body, /fixture-model:medium · 10\.0kt/);
+  host.shutdown();
+});
+
+void test("ignores checkpoint events from another session and refreshes missing runs", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-checkpoint-scope-"));
+  const directory = writeRun(join(root, "run-1"), runState());
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "other", name: "foreign", state: "awaiting" });
+  assert.ok(host.frames.every((frame) => frame === undefined));
+
+  host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1", name: "local", state: "awaiting" });
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /waiting: local/);
+  host.shutdown();
+});
+
+void test("a render failure is cleared on the next tick", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-render-cleanup-"));
+  const directory = writeRun(join(root, "run-1"), runState());
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  const factory = host.widgets.at(-1);
+  const broken = factory(host.tui, { ...theme, fg: () => { throw new Error("render failed"); } });
+  assert.deepEqual(broken.render(WIDTH), []);
+
+  host.emit(WORKFLOW_AGENT_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  assert.equal(host.widgets.at(-1), undefined, "the empty factory is unregistered");
   host.shutdown();
 });
 
@@ -233,6 +316,125 @@ void test("the receipt shows phases, per-agent models, effort and the token spli
     runId: "run-1", workflow: "smoke", state: "completed", costUsd: 0, tokens: 0, durationMs: 0,
     phases: [], phaseBoundaries: [], agents: [],
   }, true, theme).join("\n"), /run run-1/);
+});
+
+void test("resumable runs stay visible until a later terminal state", async () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-resumable-"));
+  const host = harness();
+  host.start();
+  const directories = new Map();
+  for (const [index, state] of ["interrupted", "budget_exhausted"].entries()) {
+    const id = `run-${String(index)}`;
+    const directory = writeRun(join(root, id), runState({ id, state, workflowName: state }));
+    directories.set(id, directory);
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: id, runDirectory: directory, sessionId: "session-1" });
+  }
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 150));
+  assert.equal(host.entries.length, 0);
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /interrupted|budget_exhausted/);
+
+  const directory = directories.get("run-0");
+  writeRun(directory, runState({ id: "run-0", state: "completed", workflowName: "interrupted" }));
+  host.emit(WORKFLOW_RUN_STATE_CHANGED_EVENT, { runId: "run-0", runDirectory: directory, sessionId: "session-1", state: "completed" });
+  assert.equal(host.entries.length, 0, "the state event alone is not the completion receipt");
+  host.emit(WORKFLOW_RUN_COMPLETED_EVENT, { runId: "run-0", runDirectory: directory, sessionId: "session-1" });
+  await new Promise((resolve) => globalThis.setImmediate(resolve));
+  assert.equal(host.entries.length, 1);
+  assert.equal(host.entries[0].data.state, "completed");
+  host.shutdown();
+});
+
+void test("failed receipts fall back to a failed attempt error", async () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-attempt-error-"));
+  const host = harness();
+  host.start();
+  const base = runState().agents[0];
+  const directory = writeRun(join(root, "run-1"), runState({
+    state: "failed",
+    agents: [{
+      ...base,
+      state: "failed",
+      attemptDetails: [{
+        attempt: 1,
+        transport: "local",
+        accounting: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        setup: { model: { provider: "fixture", model: "model" }, tools: [], hookNames: [], cwd: root },
+        error: { code: "AGENT_FAILED", message: "attempt error" },
+      }],
+    }],
+  }));
+  host.emit(WORKFLOW_RUN_FAILED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 150));
+  assert.equal(host.entries[0].data.error, "attempt error");
+  host.shutdown();
+});
+
+void test("failed receipts use stable persisted and attempt errors", async () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-failure-"));
+  const host = harness();
+  host.start();
+  const directory = writeRun(join(root, "run-1"), runState());
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  writeRun(directory, runState({
+    state: "failed",
+    error: { code: "AGENT_FAILED", message: "persisted error" },
+    agents: [{ ...runState().agents[0], state: "failed", attemptDetails: [{ attempt: 1, setup: { model: { provider: "fixture", model: "model" }, tools: [], hookNames: [], cwd: root }, transport: "local", accounting: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, error: { code: "AGENT_FAILED", message: "attempt error" } }] }],
+  }));
+  host.emit(WORKFLOW_RUN_FAILED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1", error: { code: "AGENT_FAILED", message: "event error" } });
+  assert.equal(host.entries.length, 1);
+  assert.equal(host.entries[0].data.error, "persisted error");
+  host.shutdown();
+});
+
+void test("receipts retain unphased nested agents and granted tools", async () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-unphased-"));
+  const base = runState().agents[0];
+  const directory = writeRun(join(root, "run-1"), runState({
+    state: "completed",
+    phaseHistory: [],
+    agents: [
+      { ...base, id: "parent", name: "parent", state: "completed", tools: ["read", "grep"] },
+      { ...base, id: "child", name: "child", parentId: "parent", state: "completed", tools: ["find"], attemptDetails: [{ session: { locator: { sessionFile: join(root, "missing.jsonl") } }, error: { code: "AGENT_FAILED", message: "attempt error" } }] },
+    ],
+  }));
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_COMPLETED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 150));
+  const receipt = host.entries[0].data;
+  assert.deepEqual(receipt.phases, ["unphased"]);
+  assert.deepEqual(receipt.phaseBoundaries, [0]);
+  assert.deepEqual(receipt.agents.map(({ name, parentId, tools, toolCalls }) => ({ name, parentId, tools, toolCalls })), [
+    { name: "parent", parentId: undefined, tools: ["read", "grep"], toolCalls: undefined },
+    { name: "child", parentId: "parent", tools: ["find"], toolCalls: undefined },
+  ]);
+  const body = renderReceipt(receipt, false, theme).map(plain).join("\n");
+  assert.ok(body.indexOf("parent") < body.indexOf("child"));
+  assert.match(body, /read grep/);
+  assert.match(body, /find/);
+  host.shutdown();
+});
+
+void test("reload reconciles on-disk runs and recovers missed receipts", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "widget-reload-cwd-"));
+  const background = new RunStore(cwd, "session-1", "reload-background");
+  const foreground = new RunStore(cwd, "session-1", "reload-foreground");
+  writeRun(background.directory, runState({ id: "reload-background", workflowName: "recovered", cwd, delivery: { mode: "background", state: "pending" } }));
+  writeRun(foreground.directory, runState({ id: "reload-foreground", workflowName: "foreground", cwd, delivery: { mode: "foreground", state: "attached" } }));
+  const host = harness("session-1", { cwd });
+  host.start();
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 150));
+  assert.match(host.frames.at(-1).map(plain).join("\n"), /recovered/);
+  assert.doesNotMatch(host.frames.at(-1).map(plain).join("\n"), /foreground/);
+
+  writeRun(background.directory, runState({ id: "reload-background", workflowName: "recovered", cwd, state: "completed", delivery: { mode: "background", state: "pending" } }));
+  host.reload();
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 150));
+  assert.equal(host.entries.length, 1);
+  assert.equal(host.entries[0].data.runId, "reload-background");
+  host.shutdown();
+  rmSync(background.directory, { recursive: true, force: true });
+  rmSync(foreground.directory, { recursive: true, force: true });
 });
 
 void test("the border lines up at every width the TUI asks for", () => {
@@ -354,6 +556,25 @@ void test("a quiet agent is flagged early, a stalled one more loudly", () => {
   host.shutdown();
 });
 
+void test("only running agents can become quiet", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-quiet-states-"));
+  const state = runState();
+  const oldTranscript = join(root, "old.jsonl");
+  writeFileSync(oldTranscript, "{}\n");
+  utimesSync(oldTranscript, new Date(Date.now() - 5 * 60_000), new Date(Date.now() - 5 * 60_000));
+  const attemptDetails = [{ attempt: 1, transport: "local", session: { locator: { sessionFile: oldTranscript } } }];
+  const agents = ["queued", "paused", "retrying", "waiting_for_child"].map((agentState, index) => ({
+    ...state.agents[0], id: `agent-${String(index)}`, name: agentState, state: agentState, lastEventAt: Date.now() - 5 * 60_000, attemptDetails,
+  }));
+  const directory = writeRun(join(root, "run-1"), { ...state, phaseHistory: [{ phase: "work", afterAgent: 0 }], agents });
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  const body = host.frames.at(-1).map(plain).join("\n");
+  assert.doesNotMatch(body, /quiet|stalled/);
+  host.shutdown();
+});
+
 void test("a retry is visible while it is happening, not only in the receipt", () => {
   const root = mkdtempSync(join(tmpdir(), "widget-retry-"));
   const state = runState();
@@ -417,24 +638,22 @@ void test("a checkpoint waiting on a person is shown, and clears when answered",
   host.start();
   host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
 
-  host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, { runId: "run-1", name: "merge the MR?", state: "awaiting" });
+  host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1", name: "merge the MR?", state: "awaiting" });
   assert.match(host.frames.at(-1).map(plain).join("\n"), /waiting: merge the MR\?/, "the question is shown");
 
   // A re-read of the state file must not lose it: disk knows nothing of checkpoints.
   host.emit(WORKFLOW_RUN_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
   assert.match(host.frames.at(-1).map(plain).join("\n"), /waiting: merge the MR\?/, "it survives a state re-read");
 
-  host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, { runId: "run-1", name: "merge the MR?", state: "approved" });
+  host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1", name: "merge the MR?", state: "approved" });
   assert.doesNotMatch(host.frames.at(-1).map(plain).join("\n"), /waiting/, "answering clears it");
 
   host.shutdown();
 });
 
-void test("the receipt counts what an agent did, not what it was allowed to do", () => {
-  // The permitted toolbox is a property of the role, identical on every run
-  // that uses it, and an agent with no role inherits sixty-odd names that say
-  // nothing while pushing the rest of the receipt off the screen. The number
-  // of calls is what differs from run to run.
+void test("older receipts still render their tool-call counts", () => {
+  // Receipts written before granted tools were persisted contain only a call
+  // count; keep those transcript entries readable.
   const lines = renderReceipt(
     {
       runId: "run-1",
@@ -840,6 +1059,43 @@ void test("the shortcut scrolls the widget through a tree too tall to show", () 
   host.shutdown();
 });
 
+void test("alt+o does not enter or bank scrolling when the tree fits", () => {
+  __navigationForTests.enabled = true;
+  const root = mkdtempSync(join(tmpdir(), "widget-fit-scroll-"));
+  const host = harness();
+  host.start();
+  const directory = writeRun(join(root, "run-1"), runState({
+    agents: [],
+    phaseHistory: Array.from({ length: 7 }, (_, index) => ({ phase: `phase-${String(index)}`, afterAgent: 0 })),
+  }));
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  const shortcut = [...host.shortcuts.values()][0];
+  const before = host.widgets.at(-1)(host.tui, theme).render(WIDTH);
+  shortcut.handler();
+  assert.equal(host.key("\u001b[1;1:1B"), false);
+  assert.deepEqual(host.widgets.at(-1)(host.tui, theme).render(WIDTH), before);
+  host.shutdown();
+});
+
+void test("scroll mode yields arrows when a repaint leaves a fitting tree", () => {
+  __navigationForTests.enabled = true;
+  const root = mkdtempSync(join(tmpdir(), "widget-scroll-shrink-"));
+  const host = harness();
+  host.start();
+  const directory = writeRun(join(root, "run-1"), runState({
+    phaseHistory: Array.from({ length: 10 }, (_, index) => ({ phase: `phase-${String(index)}`, afterAgent: 0 })),
+    agents: [],
+  }));
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  [...host.shortcuts.values()][0].handler();
+  assert.equal(host.key("\u001b[1;1:1B"), true);
+
+  writeRun(directory, runState({ agents: [], phaseHistory: [{ phase: "phase-0", afterAgent: 0 }] }));
+  host.emit(WORKFLOW_AGENT_STATE_CHANGED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+  assert.equal(host.key("\u001b[1;1:1B"), false);
+  host.shutdown();
+});
+
 
 void test("scrolling is visibly a mode: coloured rules, a scrollbar and a way out", () => {
   // Entering a mode that looks identical to not being in it is how a keypress
@@ -1067,6 +1323,8 @@ void test("a run header survives however many checkpoints are waiting", () => {
   for (let index = 0; index < 7; index += 1) {
     host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, {
       runId: `run-${String(index)}`,
+      runDirectory: join(root, `run-${String(index)}`),
+      sessionId: "session-1",
       state: "awaiting",
       name: `approve-${String(index)}`,
     });
@@ -1077,5 +1335,22 @@ void test("a run header survives however many checkpoints are waiting", () => {
     assert.ok(frame.some((line) => line.includes(`flow-${String(index)}`)), `flow-${String(index)} is still on screen`);
   }
 
+  host.shutdown();
+});
+
+void test("marks hidden rows when run headers exceed the body budget", () => {
+  const root = mkdtempSync(join(tmpdir(), "widget-header-budget-"));
+  const host = harness();
+  host.start();
+  for (let index = 0; index < 9; index += 1) {
+    const id = `run-${String(index)}`;
+    const directory = writeRun(join(root, id), { ...runState(), id, workflowName: `flow-${String(index)}` });
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: id, runDirectory: directory, sessionId: "session-1" });
+  }
+
+  const frame = host.widgets.at(-1)(host.tui, theme).render(WIDTH).map(plain);
+  assert.ok(frame.length <= 10, "the strict frame budget still wins");
+  assert.ok(frame.some((line) => line.includes("more")), "hidden headers are accounted for");
+  assert.ok(!frame.some((line) => line.includes("flow-8")), "not every header is claimed to fit");
   host.shutdown();
 });

--- a/packages/extensions/widget/test/index.test.mjs
+++ b/packages/extensions/widget/test/index.test.mjs
@@ -3,7 +3,8 @@ import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
-import widget, { renderReceipt } from "../dist/index.js";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import widget, { renderReceipt, __navigationForTests } from "../dist/index.js";
 import {
   WORKFLOW_AGENT_STATE_CHANGED_EVENT,
   WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT,
@@ -15,7 +16,9 @@ import {
 // Stands in for Pi's theme. `bg` wraps rather than colours so a test can see
 // which row was highlighted without matching escape codes.
 const theme = {
-  fg: (_colour, text) => text,
+  // Real themes emit a colour and a full reset; the reset is what used to eat
+  // the selection background, so the stand-in reproduces it.
+  fg: (_colour, text) => `\u001b[38;5;12m${text}\u001b[0m`,
   bold: (text) => text,
   bg: (_colour, text) => `\u0001${text}\u0001`,
 };
@@ -315,12 +318,15 @@ void test("a quiet agent is flagged early, a stalled one more loudly", () => {
   const oldTranscript = join(root, "old.jsonl");
   writeFileSync(oldTranscript, "{}\n");
   utimesSync(oldTranscript, new Date(Date.now() - 4 * 60_000), new Date(Date.now() - 4 * 60_000));
-  const sessions = [{ transport: "local", sessionId: "s", locator: { sessionFile: oldTranscript } }];
+  const session = { transport: "local", sessionId: "s", locator: { sessionFile: oldTranscript } };
 
   const quiet = writeRun(join(root, "run-1"), {
     ...state,
-    agentSessions: sessions,
-    agents: [{ ...state.agents[0], lastEventAt: Date.now() - 4 * 60_000 }],
+    agents: [{
+      ...state.agents[0],
+      lastEventAt: Date.now() - 4 * 60_000,
+      attemptDetails: [{ attempt: 1, transport: "local", session }],
+    }],
   });
   host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: quiet, sessionId: "session-1" });
   assert.match(host.frames.at(-1).map(plain).join("\n"), /quiet 04:0\d/, "the silence is shown with its length");
@@ -332,8 +338,15 @@ void test("a quiet agent is flagged early, a stalled one more loudly", () => {
 
   const stalled = writeRun(join(root, "run-2"), {
     ...state,
-    agentSessions: [{ transport: "local", sessionId: "s2", locator: { sessionFile: deadTranscript } }],
-    agents: [{ ...state.agents[0], lastEventAt: Date.now() - 11 * 60_000 }],
+    agents: [{
+      ...state.agents[0],
+      lastEventAt: Date.now() - 11 * 60_000,
+      attemptDetails: [{
+        attempt: 1,
+        transport: "local",
+        session: { transport: "local", sessionId: "s2", locator: { sessionFile: deadTranscript } },
+      }],
+    }],
   });
   host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-2", runDirectory: stalled, sessionId: "session-1" });
   assert.match(host.frames.at(-1).map(plain).join("\n"), /stalled 11:0\d/, "a stalled agent says so");
@@ -486,8 +499,15 @@ void test("a busy agent is not called quiet just because the run state is stale"
   const state = runState();
   const stale = {
     ...state,
-    agentSessions: [{ transport: "local", sessionId: "s", locator: { sessionFile: transcript } }],
-    agents: [{ ...state.agents[0], lastEventAt: Date.now() - 8 * 60_000 }],
+    agents: [{
+      ...state.agents[0],
+      lastEventAt: Date.now() - 8 * 60_000,
+      attemptDetails: [{
+        attempt: 1,
+        transport: "local",
+        session: { transport: "local", sessionId: "s", locator: { sessionFile: transcript } },
+      }],
+    }],
   };
   const directory = writeRun(join(root, "run-1"), stale);
 
@@ -539,9 +559,11 @@ void test("a busy screen still produces a frame Pi will not truncate", () => {
   }
 
   const frame = host.frames.at(-1);
-  assert.ok(frame.length <= 20, `the frame stays within its row budget, got ${frame.length}`);
-  // Side rules only: no lid, no floor. Every row carries one on each edge.
-  for (const line of frame) assert.match(plain(line), /^│.*│$/, `a rule on both edges, got: ${plain(line)}`);
+  assert.ok(frame.length <= 10, `the frame stays within its row budget, got ${frame.length}`);
+  // A lid on the title row, side rules between, a floor to close it.
+  assert.match(plain(frame[0]), /^╭.*╮$/, `the lid rides the title row, got: ${plain(frame[0])}`);
+  assert.match(plain(frame.at(-1)), /^╰─+╯$/, `the box closes, got: ${plain(frame.at(-1))}`);
+  for (const line of frame.slice(1, -1)) assert.match(plain(line), /^│.*│$/, `a rule on both edges, got: ${plain(line)}`);
 
   // Folding must not hide the work that is actually happening.
   const text = frame.map(plain).join("\n");
@@ -637,191 +659,423 @@ void test("a foreground run leaves no receipt either", async () => {
 });
 
 
-void test("the widget sits below the editor and walks its rows on ↓", () => {
-  // Focus is taken only from an empty editor, on the one key that has nothing
-  // else to do there, and handed back the moment anything is typed. A widget
-  // that held the keyboard any longer would be one you had to fight past.
-  const root = mkdtempSync(join(tmpdir(), "widget-focus-"));
+
+
+
+
+
+
+
+void test("every colour comes from the theme", () => {
+  // Hardcoded 24-bit escapes look right on one terminal and wrong on a
+  // 256-colour or light theme, and ignore whatever the reader chose. Rendering
+  // with a theme that paints nothing must therefore produce no colour at all.
+  const root = mkdtempSync(join(tmpdir(), "widget-theme-"));
   const host = harness();
   host.start();
+
+  const directory = writeRun(join(root, "run-1"), runState());
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  const colourless = { fg: (_colour, text) => text, bold: (text) => text, bg: (_colour, text) => text };
+  const frame = host.widgets.at(-1)(host.tui, colourless).render(WIDTH);
+
+  const coloured = frame.filter((line) => line.includes("\u001b["));
+  assert.deepEqual(coloured, [], "a theme that paints nothing leaves no escapes behind");
+
+  host.shutdown();
+});
+
+void test("one busy agent does not vouch for a silent one", () => {
+  // Silence used to be measured across every session in the run, so the newest
+  // write anywhere made every agent look alive. Two agents, one working and one
+  // that stopped, then read identically — and the one that stopped is the whole
+  // reason to look.
+  const root = mkdtempSync(join(tmpdir(), "widget-per-agent-"));
+
+  const busy = join(root, "busy.jsonl");
+  const silent = join(root, "silent.jsonl");
+  writeFileSync(busy, "{}\n");
+  writeFileSync(silent, "{}\n");
+  const longAgo = new Date(Date.now() - 5 * 60_000);
+  utimesSync(silent, longAgo, longAgo);
+
+  const state = runState();
+  const attempt = (file) => [{
+    attempt: 1,
+    transport: "local",
+    session: { transport: "local", sessionId: file, locator: { sessionFile: file } },
+  }];
 
   const directory = writeRun(join(root, "run-1"), {
-    ...runState(),
-    phaseHistory: [{ phase: "discover", afterAgent: 0 }, { phase: "plan", afterAgent: 1 }],
+    ...state,
+    phaseHistory: [{ phase: "work", afterAgent: 0 }],
     agents: [
-      { ...runState().agents[0], state: "completed" },
-      { ...runState().agents[0], id: "a2", name: "planner", state: "running" },
+      { ...state.agents[0], id: "a1", name: "worker", lastEventAt: Date.now(), attemptDetails: attempt(busy) },
+      { ...state.agents[0], id: "a2", name: "waiter", lastEventAt: Date.now() - 5 * 60_000, attemptDetails: attempt(silent) },
     ],
   });
+
+  const host = harness();
+  host.start();
   host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
 
-  assert.equal(host.placements.at(-1), "belowEditor", "below the editor, not above it");
+  const frame = host.frames.at(-1).map(plain);
+  const worker = frame.find((line) => line.includes("worker"));
+  const waiter = frame.find((line) => line.includes("waiter"));
+  assert.ok(!worker.includes("quiet"), "the working agent is not flagged");
+  assert.match(waiter, /quiet 05:0\d/, "the silent one is, on its own transcript");
 
-  // Captured from a live session: with the kitty keyboard protocol, which Pi
-  // negotiates, an arrow arrives parameterised rather than as a bare `\x1b[B`.
-  // `:1` is the press, `:3` its release, and `:2` the repeat while held — the
-  // counts in that capture came in `:1`/`:3` pairs with a long `:2` run.
-  const DOWN = "\u001b[1;1:1B";
-  const DOWN_RELEASE = "\u001b[1;1:3B";
-  const DOWN_REPEAT = "\u001b[1;1:2B";
-  const UP = "\u001b[1;1:1A";
-  const ESC = "\u001b";
+  host.shutdown();
+});
 
-  // With text in the editor, ↓ belongs to the editor.
-  host.setEditorText("some text");
-  assert.equal(host.key(DOWN), false, "a keystroke meant for the editor is left alone");
+void test("agents nest under their parent, by the label the workflow gave them", () => {
+  // A spawned agent drawn as a sibling hides who asked for it, and its cost
+  // reads as a peer's rather than part of the parent's. The label is what the
+  // workflow called this one; the name is the role it was built from, which
+  // two agents can share.
+  const root = mkdtempSync(join(tmpdir(), "widget-nest-"));
+  const state = runState();
+  const base = state.agents[0];
+
+  const directory = writeRun(join(root, "run-1"), {
+    ...state,
+    phaseHistory: [{ phase: "work", afterAgent: 0 }],
+    agents: [
+      { ...base, id: "p", name: "developer", label: "developer (api)", state: "running" },
+      { ...base, id: "c", name: "reviewer", parentId: "p", state: "running" },
+    ],
+  });
+
+  const host = harness();
+  host.start();
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  const frame = host.frames.at(-1).map(plain);
+  const parent = frame.findIndex((line) => line.includes("developer (api)"));
+  const child = frame.findIndex((line) => line.includes("reviewer"));
+
+  assert.ok(parent >= 0, "the label is used, not the bare role name");
+  assert.ok(child > parent, "the child is drawn under its parent");
+
+  const indent = (line) => line.length - line.replace(/^│\s+/, "").length;
+  assert.ok(indent(frame[child]) > indent(frame[parent]), "and indented beneath it");
+
+  host.shutdown();
+});
+
+void test("with scrolling off the widget claims no keys at all", () => {
+  // The behaviour is finished but withheld until there is something to do
+  // once inside. While it is off, `↓` and the shortcut must reach whatever
+  // else wants them — a widget that swallows keys to offer nothing back is
+  // worse than one that stays out of the way.
+  __navigationForTests.enabled = false;
+
+  const root = mkdtempSync(join(tmpdir(), "widget-off-"));
+  const host = harness();
+  host.start();
+
+  const directory = writeRun(join(root, "run-1"), runState());
+  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
+
+  assert.equal(host.shortcuts.size, 0, "no shortcut is registered");
 
   host.setEditorText("");
-  assert.equal(host.key(DOWN), true, "↓ on an empty editor takes focus");
-  assert.equal(host.key(DOWN_RELEASE), true, "the release half is swallowed, not acted on");
-  assert.equal(host.key(DOWN), true, "and moves down");
-  assert.equal(host.key(DOWN_REPEAT), true, "holding the key keeps moving");
-  assert.equal(host.key(UP), true, "and back up");
+  assert.equal(host.key("\u001b[1;1:1B"), false, "↓ passes through untouched");
 
-  // The bare form still works where a terminal speaks the older protocol.
-  assert.equal(host.key("\u001b[B"), true, "the unparameterised arrow is understood too");
-
-  const rendered = host.widgets.at(-1)(host.tui, theme).render(WIDTH);
-  const selected = rendered.filter((line) => line.includes("\u0001"));
-  assert.equal(selected.length, 1, "exactly one row is lit");
-
-  assert.equal(host.key(ESC), true, "escape gives the keyboard back");
-  assert.equal(host.key("x"), false, "and typing reaches the editor again");
+  const frame = host.frames.at(-1).map(plain);
+  assert.ok(!frame[0].includes("alt+o"), "and nothing is promised in the title");
 
   host.shutdown();
 });
 
-void test("the highlight covers the whole selected row, text included", () => {
-  // A row is assembled from coloured pieces, each ending in a full reset, and
-  // a full reset clears the background too. Painted without care the highlight
-  // survives only on the indent and the tree stem, and dies behind every piece
-  // of text — a stripe rather than a selection.
-  const root = mkdtempSync(join(tmpdir(), "widget-highlight-"));
+void test("the shortcut scrolls the widget through a tree too tall to show", () => {
+  // Ten rows do not stretch to five runs three phases deep, and what is folded
+  // away at rest is chosen by the widget, not the reader. Scrolling is how the
+  // rest is reached — entered by shortcut alone, since `↓` on an empty editor
+  // belongs to whichever picker opens next.
+  __navigationForTests.enabled = true;
+  const root = mkdtempSync(join(tmpdir(), "widget-scroll-"));
   const host = harness();
   host.start();
 
-  const directory = writeRun(join(root, "run-1"), runState());
-  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
-
-  host.setEditorText("");
-  // Down onto the run header, which carries the dimmed figures on its right.
-  host.key("\u001b[1;1:1B");
-  host.key("\u001b[1;1:1B");
-
-  const lit = host.widgets.at(-1)(host.tui, theme).render(WIDTH).find((line) => line.includes("\u0001"));
-  assert.ok(lit, "a row is lit");
-
-  // Between the markers the background must never be cancelled: a full reset
-  // in there is exactly the bug.
-  const inside = lit.slice(lit.indexOf("\u0001") + 1, lit.indexOf("\u0001", lit.indexOf("\u0001") + 1));
-  assert.ok(!inside.includes("\u001b[0m"), `no full reset inside the highlight, got: ${JSON.stringify(inside)}`);
-  assert.ok(inside.includes("\u001b[39m"), "colours are still ended, just without clearing the background");
-
-  host.shutdown();
-});
-
-void test("an open menu keeps the arrow keys", () => {
-  // Every command picker leaves the editor empty while it waits for ↑/↓ —
-  // precisely the condition this widget uses to claim the key. Claiming it
-  // anyway meant `/workflow` opened a menu you could not move through.
-  const root = mkdtempSync(join(tmpdir(), "widget-menu-"));
-  const host = harness();
-  host.start();
-
-  const directory = writeRun(join(root, "run-1"), runState());
-  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
-
-  const DOWN = "\u001b[1;1:1B";
-  host.setEditorText("");
-
-  host.tui.openMenu();
-  assert.equal(host.key(DOWN), false, "the menu keeps ↓");
-
-  host.tui.closeMenu();
-  assert.equal(host.key(DOWN), true, "and the widget takes it once the menu is gone");
-
-  // A menu opening while the widget is focused takes the keyboard back.
-  host.tui.openMenu();
-  assert.equal(host.key(DOWN), false, "a menu opening over the widget wins");
-
-  // An overlay counts the same way.
-  host.tui.closeMenu();
-  host.tui.overlay = true;
-  assert.equal(host.key(DOWN), false, "an overlay keeps the keys too");
-
-  host.shutdown();
-});
-
-void test("the shortcut focuses the widget when the arrow cannot", () => {
-  // `↓` has to defer to anything else on screen, so there has to be a way in
-  // that does not — otherwise the widget is unreachable exactly when a menu
-  // happens to be open. Registering it through Pi also means it can be rebound
-  // in keybindings.json.
-  const root = mkdtempSync(join(tmpdir(), "widget-shortcut-"));
-  const host = harness();
-  host.start();
-
-  const directory = writeRun(join(root, "run-1"), runState());
-  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
-
-  const shortcut = [...host.shortcuts.values()][0];
-  assert.ok(shortcut, "a shortcut is registered");
-
-  shortcut.handler();
-  const lit = host.widgets.at(-1)(host.tui, theme).render(WIDTH).filter((line) => line.includes("\u0001"));
-  assert.equal(lit.length, 1, "the shortcut lights a row");
-
-  shortcut.handler();
-  const dark = host.widgets.at(-1)(host.tui, theme).render(WIDTH).filter((line) => line.includes("\u0001"));
-  assert.equal(dark.length, 0, "and pressing it again gives the keyboard back");
-
-  host.shutdown();
-});
-
-void test("the title row says how to get in", () => {
-  const root = mkdtempSync(join(tmpdir(), "widget-hint-"));
-  const host = harness();
-  host.start();
-
-  const directory = writeRun(join(root, "run-1"), runState());
-  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
-
-  assert.match(plain(host.frames.at(-1)[0]), /↓ or alt\+o/, "the way in is on the title row");
-
-  host.setEditorText("");
-  host.key("\u001b[1;1:1B");
-  const inside = host.widgets.at(-1)(host.tui, theme).render(WIDTH);
-  assert.match(plain(inside[0]), /↑↓ move · esc back/, "and the keys change once inside");
-
-  host.shutdown();
-});
-
-void test("focus is recognised across a duplicated TUI package", () => {
-  // npm may install a second copy of the TUI package beside the widget, so the
-  // editor Pi hands over is an instance of a *different* Editor class than any
-  // the widget could import. An identity check answers "not an editor" for the
-  // editor itself, and the widget then believes a menu is permanently open:
-  // `↓` stops working and the shortcut lights a row that vanishes on the next
-  // keystroke. Recognition by capability is immune to it.
-  const root = mkdtempSync(join(tmpdir(), "widget-dup-tui-"));
-  const host = harness();
-  host.start();
-
-  const directory = writeRun(join(root, "run-1"), runState());
-  host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: "run-1", runDirectory: directory, sessionId: "session-1" });
-
-  // An editor from a foreign copy of the package: same shape, unrelated class.
-  class ForeignEditor {
-    getText() { return ""; }
-    addToHistory() { /* nothing */ }
+  const state = runState();
+  for (const id of ["run-1", "run-2", "run-3", "run-4", "run-5"]) {
+    const directory = writeRun(join(root, id), {
+      ...state,
+      id,
+      workflowName: `flow-${id}`,
+      phaseHistory: [
+        { phase: "fetch", afterAgent: 0 },
+        { phase: "build", afterAgent: 0 },
+        { phase: "verify", afterAgent: 0 },
+      ],
+    });
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: id, runDirectory: directory, sessionId: "session-1" });
   }
-  host.tui.focus = new ForeignEditor();
 
+  const draw = () => host.widgets.at(-1)(host.tui, theme).render(WIDTH).map(plain);
+  const shortcut = [...host.shortcuts.values()][0];
+  assert.ok(shortcut, "the shortcut is registered");
+
+  const resting = draw();
+  assert.ok(resting.length <= 10, `the frame keeps its budget, got ${resting.length}`);
+  assert.ok(resting.some((line) => line.includes("more")), "and says how much is hidden");
+
+  // `↓` is left alone until the shortcut says otherwise.
   host.setEditorText("");
-  assert.equal(host.key("\u001b[1;1:1B"), true, "↓ still works with a foreign editor focused");
+  assert.equal(host.key("\u001b[1;1:1B"), false, "↓ is not claimed at rest");
 
-  const lit = host.widgets.at(-1)(host.tui, theme).render(WIDTH).filter((line) => line.includes("\u0001"));
-  assert.equal(lit.length, 1, "and the row stays lit");
+  shortcut.handler();
+  assert.equal(host.key("\u001b[1;1:1B"), true, "and is claimed while scrolling");
+  const scrolled = draw();
+  assert.notDeepEqual(scrolled, resting, "the window moved");
+  assert.ok(scrolled.length <= 10, "still within budget");
+  assert.match(scrolled[0], /↑↓ scroll · esc/, "the keys are named while scrolling");
+
+  // Escape gives the keyboard back, and the arrow with it.
+  assert.equal(host.key("\u001b"), true, "escape is taken");
+  assert.equal(host.key("\u001b[1;1:1B"), false, "and ↓ is free again");
+
+  host.shutdown();
+});
+
+
+void test("scrolling is visibly a mode: coloured rules, a scrollbar and a way out", () => {
+  // Entering a mode that looks identical to not being in it is how a keypress
+  // goes somewhere unexpected. The rules change colour, a scrollbar says where
+  // the window sits, and the title names the key that leaves.
+  __navigationForTests.enabled = true;
+  const root = mkdtempSync(join(tmpdir(), "widget-mode-"));
+  const host = harness();
+  host.start();
+
+  const state = runState();
+  for (const id of ["run-1", "run-2", "run-3", "run-4", "run-5"]) {
+    const directory = writeRun(join(root, id), {
+      ...state,
+      id,
+      workflowName: `flow-${id}`,
+      phaseHistory: [
+        { phase: "fetch", afterAgent: 0 },
+        { phase: "build", afterAgent: 0 },
+        { phase: "verify", afterAgent: 0 },
+      ],
+    });
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: id, runDirectory: directory, sessionId: "session-1" });
+  }
+
+  // A theme that names the colour it was asked for, so the role is checkable.
+  // Each role gets a distinct real colour code, so the choice is checkable
+  // without adding width — an invented marker would push the line past the
+  // terminal and be truncated, which is the stand-in's fault, not the widget's.
+  const codes = { accent: "\u001b[34m", warning: "\u001b[33m" };
+  const named = {
+    fg: (colour, text) => `${codes[colour] ?? "\u001b[39m"}${text}\u001b[0m`,
+    bold: (text) => text,
+    bg: (_colour, text) => text,
+  };
+  // Wide enough for the title and the hint together; the hint gives way to the
+  // title on a narrow terminal, which is its own behaviour.
+  const draw = () => host.widgets.at(-1)(host.tui, named).render(100);
+
+  const resting = draw();
+  assert.ok(resting[0].startsWith("\u001b[34m╭"), "at rest the rules are the ordinary accent");
+  assert.match(plain(resting[0]), /alt\+o to scroll/, "and the way in is named");
+  assert.ok(!resting.some((line) => line.includes("█")), "no scrollbar until it means something");
+
+  [...host.shortcuts.values()][0].handler();
+  const scrolling = draw();
+  assert.ok(scrolling[0].startsWith("\u001b[33m╭"), "scrolling recolours the rules");
+  assert.match(plain(scrolling[0]), /esc to exit/, "and names the way out");
+  assert.ok(scrolling.some((line) => line.includes("█")), "the thumb shows where the window sits");
+  assert.ok(scrolling.some((line) => line.includes("░")), "against the track it moves along");
+
+  host.shutdown();
+});
+
+/** Builds a host with `count` runs of three phases each — more tree than frame. */
+function tallTree(count = 5) {
+  const root = mkdtempSync(join(tmpdir(), "widget-tall-"));
+  const host = harness();
+  host.start();
+  for (let index = 0; index < count; index += 1) {
+    const id = `run-${String(index)}`;
+    const directory = writeRun(join(root, id), {
+      ...runState(),
+      id,
+      workflowName: `flow-${String(index)}`,
+      phaseHistory: [
+        { phase: "one", afterAgent: 0 },
+        { phase: "two", afterAgent: 0 },
+        { phase: "three", afterAgent: 0 },
+      ],
+    });
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: id, runDirectory: directory, sessionId: "session-1" });
+  }
+  return host;
+}
+
+void test("scrolling reaches the last row and stops there, with nothing banked past the end", () => {
+  // The failure this guards is invisible rather than loud: presses past the end
+  // raise an offset no row can show, and every one has to be paid back with an
+  // ↑ that appears to do nothing. Overscroll far, then check that a single ↑
+  // moves the screen.
+  __navigationForTests.enabled = true;
+  const host = tallTree();
+  const draw = () => host.widgets.at(-1)(host.tui, theme).render(WIDTH).map(plain);
+  [...host.shortcuts.values()][0].handler();
+
+  for (let press = 0; press < 40; press += 1) host.key("\u001b[1;1:1B");
+  const bottom = draw();
+  assert.ok(bottom.some((line) => line.includes("three")), "the last phase of the last run is reachable");
+  assert.ok(bottom.some((line) => line.includes("above")), "and the marker counts what is behind, not ahead");
+
+  host.key("\u001b[1;1:1A");
+  assert.notDeepEqual(draw(), bottom, "one ↑ after overscrolling moves the window");
+
+  host.shutdown();
+});
+
+void test("entering scroll mode shows the top of the tree, not the resting selection", () => {
+  // At rest the widget picks rows by rank, so what it shows is not contiguous
+  // and the gaps are unmarked. Entering on that view makes the first press look
+  // like a jump: the reader is not moving a window, they are swapping views.
+  __navigationForTests.enabled = true;
+  const host = tallTree();
+  const draw = () => host.widgets.at(-1)(host.tui, theme).render(WIDTH).map(plain);
+
+  // Contiguity is the point: the resting view drops rows silently, so a window
+  // that merely starts at the top is not enough — the rows after it must be
+  // the ones that really follow. Scrolling to the end collects every row of
+  // the tree in order; entering must show that sequence's first rows exactly.
+  [...host.shortcuts.values()][0].handler();
+  const entered = draw().slice(1, -1);
+
+  const walked = [];
+  for (let press = 0; press < 40; press += 1) {
+    for (const line of draw().slice(1, -1)) if (!line.includes("…") && !walked.includes(line)) walked.push(line);
+    host.key("\u001b[1;1:1B");
+  }
+
+  assert.deepEqual(
+    entered.filter((line) => !line.includes("…")),
+    walked.slice(0, entered.filter((line) => !line.includes("…")).length),
+    "the window opens on the first rows of the tree, in the order it walks them",
+  );
+
+  host.shutdown();
+});
+
+void test("the scrollbar thumb tracks the window it describes", () => {
+  // A thumb that reaches the bottom while rows remain, or lingers at the top
+  // after the window moved, is worse than no thumb: it is a wrong answer to
+  // the only question it is asked.
+  __navigationForTests.enabled = true;
+  const host = tallTree();
+  const thumb = () => {
+    const rows = host.widgets.at(-1)(host.tui, theme).render(WIDTH).map(plain).slice(1, -1);
+    const first = rows.findIndex((line) => line.endsWith("█"));
+    const last = rows.map((line) => line.endsWith("█")).lastIndexOf(true);
+    return { first, last, rows: rows.length };
+  };
+  [...host.shortcuts.values()][0].handler();
+
+  const top = thumb();
+  assert.equal(top.first, 0, "at the top of the tree the thumb starts at the top");
+  assert.ok(top.last < top.rows - 1, "and does not already fill the track");
+
+  for (let press = 0; press < 40; press += 1) host.key("\u001b[1;1:1B");
+  const bottom = thumb();
+  assert.equal(bottom.last, bottom.rows - 1, "at the end of the tree it reaches the bottom");
+  assert.ok(bottom.first > top.first, "having travelled there");
+
+  // And only there. A thumb clamped short of the window's own limit reaches
+  // the bottom while the content still has a row to give — a wrong answer to
+  // the one question it is asked. The track is coarser than a row, so the
+  // check is that the thumb is still moving where the window still moves:
+  // rewind to the top, then step down watching both.
+  for (let press = 0; press < 60; press += 1) host.key("\u001b[1;1:1A");
+  const body = () => host.widgets.at(-1)(host.tui, theme).render(WIDTH).map(plain).slice(1, -1).join("\n");
+  let previousBody = body();
+  let previousThumb = thumb();
+  let contentMovedAfterThumbStopped = false;
+  for (let press = 0; press < 40; press += 1) {
+    host.key("\u001b[1;1:1B");
+    const nextBody = body();
+    const nextThumb = thumb();
+    if (nextBody !== previousBody && previousThumb.last === previousThumb.rows - 1) {
+      contentMovedAfterThumbStopped = true;
+    }
+    previousBody = nextBody;
+    previousThumb = nextThumb;
+  }
+  assert.ok(!contentMovedAfterThumbStopped, "the window never moves after the thumb claims the bottom");
+
+  host.shutdown();
+});
+
+void test("lines are measured in terminal cells, not JavaScript characters", () => {
+  // Pi-tui rejects a line wider than the width it handed out — it throws, it
+  // does not wrap — and it counts display cells. A CJK ideograph is one
+  // character and two cells, so measuring with `.length` under-counts by half
+  // and hands the TUI a fatal line. Widths are checked with pi-tui's own
+  // measure, because agreeing approximately is the same as not agreeing.
+  const root = mkdtempSync(join(tmpdir(), "widget-cells-"));
+  const host = harness();
+  host.start();
+
+  const names = ["数据处理工作流程测试用例名称很长", "deploy 🚀🚀🚀🚀🚀🚀🚀🚀 prod", "ノード・ビルド・検証"];
+  names.forEach((workflowName, index) => {
+    const id = `run-${String(index)}`;
+    const directory = writeRun(join(root, id), {
+      ...runState(),
+      id,
+      workflowName,
+      phaseHistory: [{ phase: "検証", afterAgent: 0 }, { phase: "two", afterAgent: 0 }],
+    });
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: id, runDirectory: directory, sessionId: "session-1" });
+  });
+
+  const widget = host.widgets.at(-1)(host.tui, theme);
+  for (let width = 1; width <= 120; width += 1) {
+    for (const line of widget.render(width)) {
+      assert.ok(
+        visibleWidth(line) <= width,
+        `render(${String(width)}) returned a line ${String(visibleWidth(line))} cells wide`,
+      );
+    }
+  }
+
+  host.shutdown();
+});
+
+void test("a run header survives however many checkpoints are waiting", () => {
+  // Checkpoints share the top rank because they need an answer, so ranking
+  // alone lets a few early ones spend the budget before a later run's header
+  // is reached. A run missing its detail is terse; a run missing its header is
+  // invisible, and the widget exists to say what is running.
+  const root = mkdtempSync(join(tmpdir(), "widget-headers-"));
+  const host = harness();
+  host.start();
+
+  for (let index = 0; index < 8; index += 1) {
+    const id = `run-${String(index)}`;
+    const directory = writeRun(join(root, id), { ...runState(), id, workflowName: `flow-${String(index)}` });
+    host.emit(WORKFLOW_RUN_STARTED_EVENT, { runId: id, runDirectory: directory, sessionId: "session-1" });
+  }
+  for (let index = 0; index < 7; index += 1) {
+    host.emit(WORKFLOW_CHECKPOINT_STATE_CHANGED_EVENT, {
+      runId: `run-${String(index)}`,
+      state: "awaiting",
+      name: `approve-${String(index)}`,
+    });
+  }
+
+  const frame = host.widgets.at(-1)(host.tui, theme).render(WIDTH).map(plain);
+  for (let index = 0; index < 8; index += 1) {
+    assert.ok(frame.some((line) => line.includes(`flow-${String(index)}`)), `flow-${String(index)} is still on screen`);
+  }
 
   host.shutdown();
 });

--- a/packages/extensions/widget/tsconfig.json
+++ b/packages/extensions/widget/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmitOnError": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
Two independent changes.

## 1. `@piewf/widget` — a new package

While a run is going you know very little about it, and once it finishes nothing is left behind.

The widget draws live runs as a tree above the editor:

```
╭ Workflow ──────────────────────────────────────╮
│ ⣷ deliver · 03:24                              │
│   ├─ ✓ scout                                   │
│   ╰─ ⣷ build                                   │
│      ╰─ ⣷ dev  claude-opus-5:high · 02:11      │
╰────────────────────────────────────────────────╯
```

What it shows while work is happening:

- phases and the agents inside them, each agent's model and thinking level, elapsed time
- `2 commands · 00:12` — a phase running nothing but shell no longer looks dead
- `◆ waiting: ship` — the run is parked on a checkpoint, waiting for a person
- `attempt 2` — a retry is under way, and a retry doubles what the agent costs
- `near budget (costUsd)` — a budget threshold has been crossed
- `⚠ quiet 03:11` in amber and `⚠ stalled 11:04` in red — the agent has gone silent. Measured against the agent's own transcript, so an agent that is busy never raises the alarm

When a run ends the widget drops it at once and writes a receipt into the transcript instead:

```
✓ smoke 61kt · $0.08 · 01:09 · completed
├─ ✓ shell
├─ ✓ llm  61kt · $0.08
│  ╰─ ✓ scout gpt-5.6-luna:medium · $0.08 · 00:49
│       role scout · via scout-model · read grep find ls bash
│       in 61kt · out 462t · cache 164kt
╰─ ✓ done
```

That answers what it cost and who did it: the phases, each agent's model, the role and the alias it asked for, the tools the role granted, the token split between input, output and cache, the attempt count, and the reason for any failure.

The split is deliberate. The widget answers "what is happening" and holds nothing that already happened; the receipt answers "what did it cost and who did it", and keeps the answer for the life of the session.

## 2. Provider registrations from extensions — a core fix

An extension that supplies models (a proxy front-end, a corporate gateway) registers them from its factory, but a workflow agent could not see them: the queued registrations were never drained, and the request failed with `UNKNOWN_MODEL`.

The fix drains the queue before the model is resolved. The new test registers a provider only through an extension factory and fails without it.

## Checks

| | |
|---|---|
| build, lint, docs, workspace layout | clean |
| widget tests | 14 / 14 |
| herdr tests | 26 / 26 |
| core tests | 104 passing, against 103 on `main` |

Two core tests (`releases consumed scheduler result payloads`, `collected nested results are one-shot`) fail on a clean `main` at 5.2.0 as well — unrelated to these changes.
