### PR TITLE
fix(herdr): keep fully inspectable agents running after handoff

### DIFF
--- a/packages/core/src/herdr.ts
+++ b/packages/core/src/herdr.ts
@@ -116,13 +116,14 @@ function hasPiProcess(value: unknown, originatingEntrypoint?: string): boolean {
   return processes.some((candidate) => {
     const process = record(candidate);
     const name = process?.name;
+    const argv0 = process?.argv0;
     const argv = process?.argv;
     const commandLine = process?.cmdline;
     if (originatingEntrypoint) {
       if (Array.isArray(argv) && argv.some((value) => value === originatingEntrypoint) || typeof commandLine === "string" && commandLine.includes(originatingEntrypoint)) return true;
-      return name === "pi" || Array.isArray(argv) && argv[0] === "pi";
+      return name === "pi" || argv0 === "pi" || Array.isArray(argv) && argv[0] === "pi";
     }
-    return name === "pi" || Array.isArray(argv) && argv[0] === "pi" || typeof commandLine === "string" && commandLine.includes("/bin/pi");
+    return name === "pi" || argv0 === "pi" || Array.isArray(argv) && argv[0] === "pi" || typeof commandLine === "string" && commandLine.includes("/bin/pi");
   });
 }
 function isHerdrStatus(value: unknown): value is HerdrAgentStatus { return value === "idle" || value === "working" || value === "blocked" || value === "unknown" || value === "done"; }
@@ -134,12 +135,14 @@ function herdrAgentStatus(value: unknown): HerdrPaneStatus | undefined {
   const state: HerdrAgentStatus = isHerdrStatus(rawState) ? rawState : "unknown";
   return { state };
 }
-export async function waitForHerdrPane(paneId: string, runner: HerdrCommandRunner = herdrCommandRunner, options: { signal?: AbortSignal; intervalMs?: number; startupTimeoutMs?: number; originatingEntrypoint?: string; onStatus?: (state: HerdrAgentStatus) => void | Promise<void> } = {}): Promise<"closed" | "exited" | "idle" | "aborted"> {
+export async function waitForHerdrPane(paneId: string, runner: HerdrCommandRunner = herdrCommandRunner, options: { signal?: AbortSignal; intervalMs?: number; startupTimeoutMs?: number; exitGraceMs?: number; originatingEntrypoint?: string; onStatus?: (state: HerdrAgentStatus) => void | Promise<void> } = {}): Promise<"closed" | "exited" | "idle" | "aborted"> {
   const intervalMs = options.intervalMs ?? 250;
   const startupTimeoutMs = options.startupTimeoutMs ?? 10000;
+  const exitGraceMs = options.exitGraceMs ?? 5000;
   const startedAt = Date.now();
   let sawPi = false;
   let sawWorking = false;
+  let missingSince: number | undefined;
   for (;;) {
     if (options.signal?.aborted) return "aborted";
     let piRunning: boolean;
@@ -148,8 +151,12 @@ export async function waitForHerdrPane(paneId: string, runner: HerdrCommandRunne
       piRunning = hasPiProcess(json(output), options.originatingEntrypoint);
     } catch { return "closed"; }
     if (!piRunning) {
-      if (sawPi) return "exited";
+      if (sawPi) {
+        missingSince ??= Date.now();
+        if (Date.now() - missingSince >= exitGraceMs) return "exited";
+      }
     } else {
+      missingSince = undefined;
       if (!sawPi) { sawPi = true; }
       try {
         const status = herdrAgentStatus(json(await runner(["agent", "get", paneId])));

--- a/packages/core/test/herdr.test.ts
+++ b/packages/core/test/herdr.test.ts
@@ -121,7 +121,22 @@ void test("waits for Pi startup before reporting an exit", async () => {
     statusReports += 1;
     return JSON.stringify({ result: { agent: { agent_status: statusReports === 1 ? "working" : "idle" } } });
   };
-  assert.equal(await waitForHerdrPane("pane", runner, { intervalMs: 0 }), "exited");
+  assert.equal(await waitForHerdrPane("pane", runner, { intervalMs: 0, exitGraceMs: 0 }), "exited");
+  assert.equal(processReports, 3);
+});
+void test("tolerates a transient process gap while Pi starts", async () => {
+  let processReports = 0;
+  let statusReports = 0;
+  const runner = async (args: readonly string[]): Promise<string> => {
+    if (args[0] === "pane") {
+      processReports += 1;
+      const running = processReports !== 2;
+      return JSON.stringify({ result: { process_info: { foreground_processes: running ? [{ name: "pi", argv: ["pi"] }] : [] } } });
+    }
+    statusReports += 1;
+    return JSON.stringify({ result: { agent: { agent_status: statusReports === 1 ? "working" : "idle" } } });
+  };
+  assert.equal(await waitForHerdrPane("pane", runner, { intervalMs: 0 }), "idle");
   assert.equal(processReports, 3);
 });
 void test("accepts Herdr-normalized Pi processes after exact startup", async () => {
@@ -131,10 +146,10 @@ void test("accepts Herdr-normalized Pi processes after exact startup", async () 
     if (args[1] !== "process-info") return "";
     processReports += 1;
     if (processReports === 1) return JSON.stringify({ result: { process_info: { foreground_processes: [{ name: "node", argv: [process.execPath, originatingEntrypoint], cmdline: `${process.execPath} ${originatingEntrypoint}` }] } } });
-    if (processReports === 2) return JSON.stringify({ result: { process_info: { foreground_processes: [{ name: "pi", argv: ["pi"], cmdline: "pi" }] } } });
+    if (processReports === 2) return JSON.stringify({ result: { process_info: { foreground_processes: [{ name: "node", argv0: "pi" }] } } });
     return JSON.stringify({ result: { process_info: { foreground_processes: [] } } });
   };
-  assert.equal(await waitForHerdrPane("pane", runner, { originatingEntrypoint, intervalMs: 0 }), "exited");
+  assert.equal(await waitForHerdrPane("pane", runner, { originatingEntrypoint, intervalMs: 0, exitGraceMs: 0 }), "exited");
   assert.equal(processReports, 3);
 });
 

--- a/packages/extensions/herdr/index.ts
+++ b/packages/extensions/herdr/index.ts
@@ -136,6 +136,18 @@ function sessionPath(reference: WorkflowAgentSessionReference | undefined): stri
   return locator && typeof locator === "object" && !Array.isArray(locator) && typeof locator.sessionFile === "string" ? locator.sessionFile : undefined;
 }
 
+function materializeSessionForHandoff(session: HerdrSession, prepared: Readonly<PreparedAgentSession>): void {
+  const path = sessionPath(session.reference);
+  if (!path || existsSync(path)) return;
+  const manager = SessionManager.inMemory(prepared.cwd, session.reference.sessionId ? { id: session.reference.sessionId } : undefined);
+  manager.appendSessionInfo(prepared.sessionLabel);
+  const header = manager.getHeader();
+  if (!header) throw new Error("Herdr cannot materialize a workflow session without a session header.");
+  const content = [header, ...manager.getEntries()].map((entry) => JSON.stringify(entry)).join("\n") + "\n";
+  try { writeFileSync(path, content, { encoding: "utf8", flag: "wx", mode: 0o600 }); }
+  catch (error) { if (!error || typeof error !== "object" || !("code" in error) || error.code !== "EEXIST") throw error; }
+}
+
 async function createBridgeContext(session: HerdrSession, prepared: Readonly<PreparedAgentSession>): Promise<(signal: AbortSignal, abort: () => void) => ExtensionContext> {
   const reference = session.reference;
   const path = sessionPath(reference);
@@ -380,6 +392,7 @@ function herdrTransport(agent: AgentSetup, context: Readonly<AgentSetupContext>,
         try {
           if (session.suspendForHandoff) { await session.suspendForHandoff(); suspended = true; }
           else { await session.abort(); suspended = true; }
+          materializeSessionForHandoff(session, prepared);
           return await launchPane({ session, prepared, identity: context.identity, run: context.run, attempt: sessionContext.attempt, runner, fullyInspectable, env, signal: sessionContext.signal, prompt, workspaces, tuiIndex: context.tuiIndex, tuiLabel: context.tuiLabel });
         } catch (error) {
           if (suspended) { try { await session.resumeFromHandoff?.(); } catch { /* Preserve the pane launch failure. */ } }

--- a/packages/extensions/herdr/package.json
+++ b/packages/extensions/herdr/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json",
-    "test": "npm run build && node --test --test-timeout=30000 --test-force-exit test/index.test.mjs",
+    "test": "npm run build && node --test --test-timeout=60000 --test-force-exit test/index.test.mjs",
     "prepack": "npm run build",
     "lint": "eslint ."
   },

--- a/packages/extensions/herdr/test/index.test.mjs
+++ b/packages/extensions/herdr/test/index.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { createServer } from "node:http";
 import { join } from "node:path";
@@ -764,9 +764,41 @@ void test("disposes a Herdr wrapper while a subsequent pane is still launching",
     finally { await new Promise((resolve) => { if (!server) resolve(); else server.close(() => resolve()); }); await rm(root, { recursive: true, force: true }); }
   }
 });
+void test("materializes a fresh session before launching a fully inspectable agent", async () => {
+  const root = mkdtempSync(join(tmpdir(), "herdr-extension-fresh-session-"));
+  const agentDir = join(root, "agent");
+  const sessionFile = join(root, "fresh.jsonl");
+  mkdirSync(join(agentDir, "pi-extensible-workflows"), { recursive: true });
+  writeFileSync(join(agentDir, "pi-extensible-workflows", "settings.json"), JSON.stringify({ extensionSettings: { herdr: { enableFullyInspectableMode: true } } }));
+  const runner = async (args) => {
+    if (args[0] === "workspace" && args[1] === "create") return JSON.stringify({ result: { workspace: { workspace_id: "workspace" }, tab: { tab_id: "root-tab" }, root_pane: { pane_id: "root-pane" } } });
+    if (args[0] === "tab" && args[1] === "create") return JSON.stringify({ result: { tab: { tab_id: "agent-tab" }, root_pane: { pane_id: "agent-pane" } } });
+    if (args[0] === "pane" && args[1] === "run") {
+      assert.equal(existsSync(sessionFile), true, "the session must exist before Pi starts in Herdr");
+      const entries = readFileSync(sessionFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      assert.deepEqual(entries.map(({ type }) => type), ["session", "session_info"]);
+      assert.equal(entries[0].id, "019fa4aa-610a-7459-832c-347866c35c5b");
+      assert.equal(entries[0].cwd, "/repo");
+      assert.equal(entries[1].name, "flow:review");
+    }
+    return "";
+  };
+  const extension = createHerdrExtension({ agentDir, env: { HERDR_ENV: "1", HERDR_SOCKET_PATH: "/tmp/herdr.sock", HERDR_PANE_ID: "parent" }, runner });
+  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "019fa4aa-610a-7459-832c-347866c35c5b", locator: { sessionFile } }, suspendForHandoff: async () => {}, getLastAssistant: () => ({ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "done" }] }), dispose: async () => {}, getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }) }; } } };
+  const identity = { structuralPath: ["review"], parentBreadcrumb: "flow", callSite: "agent", occurrence: 1 };
+  extension.agentSetupHooks.fullyInspectable.setup(agent, { identity, run: { runId: "run", workflow: { name: "flow" } }, signal: new AbortController().signal });
+  const prepared = { cwd: "/repo", model: { provider: "fake", model: "model" }, tools: [], initialPrompt: "work", sessionLabel: "flow:review", piRuntime };
+  try {
+    const session = await agent.transport.createSession(prepared, { identity, attempt: 1 });
+    await session.dispose();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
 void test("routes fully inspectable agents into one labeled workflow workspace", async () => {
   const root = mkdtempSync(join(tmpdir(), "herdr-extension-full-"));
   const agentDir = join(root, "agent");
+  const sessionFile = join(root, "session.jsonl");
   mkdirSync(agentDir, { recursive: true });
   mkdirSync(join(agentDir, "pi-extensible-workflows"), { recursive: true });
   writeFileSync(join(agentDir, "pi-extensible-workflows", "settings.json"), JSON.stringify({ extensionSettings: { herdr: { enableFullyInspectableMode: true } } }));
@@ -788,7 +820,7 @@ void test("routes fully inspectable agents into one labeled workflow workspace",
   const extension = createHerdrExtension({ agentDir, env: { HERDR_ENV: "1", HERDR_SOCKET_PATH: "/tmp/herdr.sock", HERDR_PANE_ID: "parent" }, runner });
   const prepared = { cwd: "/repo", model: { provider: "openai", model: "gpt" }, tools: ["read"], systemPromptPath: "/repo/.pi/pi-extensible-workflows/SYSTEM.md", contextFiles: ["project"], initialPrompt: "x".repeat(5000), sessionLabel: "flow:review:attempt-1", piRuntime };
   let received;
-  const agent = { transport: { id: "local", async createSession(value) { received = value; return { reference: { transport: "local", sessionId: "session", locator: { sessionFile: "/tmp/herdr-test.jsonl" } }, getHerdrContextFiles: () => [{ path: "/repo/AGENTS.md", content: "project instructions" }], getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }), subscribe: () => () => {}, prompt: async () => ({}), steer: async () => {}, abort: async () => {}, dispose: async () => {} }; } } };
+  const agent = { transport: { id: "local", async createSession(value) { received = value; return { reference: { transport: "local", sessionId: "session", locator: { sessionFile } }, getHerdrContextFiles: () => [{ path: "/repo/AGENTS.md", content: "project instructions" }], getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }), subscribe: () => () => {}, prompt: async () => ({}), steer: async () => {}, abort: async () => {}, dispose: async () => {} }; } } };
   const identity = { structuralPath: ["review"], parentBreadcrumb: "flow", callSite: "function:agent/work", occurrence: 1 };
   extension.agentSetupHooks.fullyInspectable.setup(agent, { identity, run: { runId: "run", workflow: { name: "flow" } }, signal: new AbortController().signal, tuiIndex: 1, tuiLabel: "reviewer" });
   const session = await agent.transport.createSession(prepared, { identity, attempt: 1 });
@@ -812,10 +844,12 @@ void test("routes fully inspectable agents into one labeled workflow workspace",
   assert.match(runCommand, /--append-system-prompt '.*pi-herdr-context-prompt-/);
   assert.ok(runCommand.includes(`@'${join(tmpdir(), "pi-herdr-prompt-")}`));
   assert.ok(runCommand.length < 4096);
+  await rm(root, { recursive: true, force: true });
 });
 void test("hands off sequential fully inspectable prompts and cleans the active tab on abort", async () => {
   const root = mkdtempSync(join(tmpdir(), "herdr-extension-sequential-"));
   const agentDir = join(root, "agent");
+  const sessionFile = join(root, "session.jsonl");
   mkdirSync(join(agentDir, "pi-extensible-workflows"), { recursive: true });
   writeFileSync(join(agentDir, "pi-extensible-workflows", "settings.json"), JSON.stringify({ extensionSettings: { herdr: { enableFullyInspectableMode: true } } }));
   const calls = [];
@@ -832,7 +866,7 @@ void test("hands off sequential fully inspectable prompts and cleans the active 
   const extension = createHerdrExtension({ agentDir, env: { HERDR_ENV: "1", HERDR_SOCKET_PATH: "/tmp/herdr.sock", HERDR_PANE_ID: "parent" }, runner });
   const ownership = [];
   const controller = new AbortController();
-  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "session", locator: { sessionFile: "/tmp/herdr-test.jsonl" } }, suspendForHandoff: async () => ownership.push("suspend"), resumeFromHandoff: async () => ownership.push("resume"), abort: async () => ownership.push("abort"), getLastAssistant: () => ({ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "done" }] }), dispose: async () => {}, getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }) }; } } };
+  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "session", locator: { sessionFile } }, suspendForHandoff: async () => ownership.push("suspend"), resumeFromHandoff: async () => ownership.push("resume"), abort: async () => ownership.push("abort"), getLastAssistant: () => ({ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "done" }] }), dispose: async () => {}, getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }) }; } } };
   const run = { runId: "run", workflow: { name: "flow" } };
   const context = { identity: { structuralPath: ["review"], parentBreadcrumb: "flow", callSite: "agent", occurrence: 1 }, run, signal: controller.signal, tuiIndex: 1, tuiLabel: "reviewer" };
   extension.agentSetupHooks.fullyInspectable.setup(agent, context);
@@ -854,6 +888,7 @@ void test("hands off sequential fully inspectable prompts and cleans the active 
 void test("bridges unknown tools and aborts forwarded tool calls", async () => {
   const root = mkdtempSync(join(tmpdir(), "herdr-extension-bridge-"));
   const agentDir = join(root, "agent"); mkdirSync(join(agentDir, "pi-extensible-workflows"), { recursive: true });
+  const sessionFile = join(root, "session.jsonl");
   writeFileSync(join(agentDir, "pi-extensible-workflows", "settings.json"), JSON.stringify({ extensionSettings: { herdr: { enableFullyInspectableMode: true } } }));
   let runCommand; const calls = [];
   const runner = async (args) => {
@@ -866,7 +901,7 @@ void test("bridges unknown tools and aborts forwarded tool calls", async () => {
   };
   const entered = []; const tool = { name: "slow", label: "Slow", description: "Wait", parameters: { type: "object", properties: {}, additionalProperties: false }, async execute(_id, _params, signal) { entered.push(true); await new Promise((resolve, reject) => { const abort = () => reject(new Error("tool observed abort")); if (signal.aborted) abort(); else signal.addEventListener("abort", abort, { once: true }); }); return { content: [{ type: "text", text: "done" }] }; } };
   const herdr = createHerdrExtension({ agentDir, env: { HERDR_ENV: "1", HERDR_SOCKET_PATH: "/tmp/herdr.sock", HERDR_PANE_ID: "parent" }, runner });
-  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "session", locator: { sessionFile: "/tmp/herdr-test.jsonl" } }, getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }), prompt: async () => ({}), abort: async () => {}, dispose: async () => {} }; } } };
+  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "session", locator: { sessionFile } }, getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }), prompt: async () => ({}), abort: async () => {}, dispose: async () => {} }; } } };
   const controller = new AbortController();
   herdr.agentSetupHooks.fullyInspectable.setup(agent, { identity: { structuralPath: ["review"], parentBreadcrumb: "flow", callSite: "agent", occurrence: 1 }, run: { runId: "run", workflow: { name: "flow" } }, signal: controller.signal });
   const prepared = { cwd: "/repo", model: { provider: "fake", model: "model" }, tools: [], customTools: [tool], initialPrompt: "work", sessionLabel: "flow:review", piRuntime };
@@ -909,6 +944,7 @@ void test("default workspace manager reuses one workspace and closes it once on 
   resetWorkflowRegistry();
   const root = mkdtempSync(join(tmpdir(), "herdr-extension-workspace-lifecycle-"));
   const agentDir = join(root, "agent");
+  const sessionFile = join(root, "session.jsonl");
   mkdirSync(join(agentDir, "pi-extensible-workflows"), { recursive: true });
   writeFileSync(join(agentDir, "pi-extensible-workflows", "settings.json"), JSON.stringify({ extensionSettings: { herdr: { enableFullyInspectableMode: true } } }));
   const handlers = new Map();
@@ -928,7 +964,7 @@ void test("default workspace manager reuses one workspace and closes it once on 
   const hook = loadingRegistry().agentSetupHooks().find(({ name }) => name === "fullyInspectable");
   assert.ok(hook);
   const run = { runId: "run", workflow: { name: "flow" } };
-  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: `session-${value.initialPrompt}`, locator: { sessionFile: "/tmp/herdr-test.jsonl" } }, suspendForHandoff: async () => {}, getLastAssistant: () => ({ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "done" }] }), dispose: async () => {}, getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }) }; } } };
+  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: `session-${value.initialPrompt}`, locator: { sessionFile } }, suspendForHandoff: async () => {}, getLastAssistant: () => ({ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "done" }] }), dispose: async () => {}, getState: () => ({ model: value.model, tools: value.tools }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }) }; } } };
   hook.setup(agent, { identity: { structuralPath: ["review"], parentBreadcrumb: "flow", callSite: "agent", occurrence: 1 }, run, signal: new AbortController().signal });
   const prepared = { cwd: "/repo", model: { provider: "fake", model: "model" }, tools: [], initialPrompt: "work", sessionLabel: "flow:review", piRuntime };
   const first = await agent.transport.createSession(prepared, { attempt: 1 });
@@ -946,6 +982,7 @@ void test("default workspace manager reuses one workspace and closes it once on 
 void test("relays generated tool bridge results, errors, and updates", async () => {
   const root = mkdtempSync(join(tmpdir(), "herdr-extension-tool-bridge-"));
   const agentDir = join(root, "agent"); mkdirSync(join(agentDir, "pi-extensible-workflows"), { recursive: true });
+  const sessionFile = join(root, "session.jsonl");
   writeFileSync(join(agentDir, "pi-extensible-workflows", "settings.json"), JSON.stringify({ extensionSettings: { herdr: { enableFullyInspectableMode: true } } }));
   let runCommand;
   const runner = async (args) => {
@@ -967,7 +1004,7 @@ void test("relays generated tool bridge results, errors, and updates", async () 
   const resolvedModel = { provider: "inline-only", id: "inline-model" };
   const resolvedRegistry = { find: (provider, model) => provider === resolvedModel.provider && model === resolvedModel.id ? resolvedModel : undefined };
   // The shared registry can arrive before the live session exposes its model.
-  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "session", locator: { sessionFile: "/tmp/herdr-test.jsonl" } }, getState: () => ({ model: value.model, tools: value.tools }), getHerdrModelContext: () => ({ model: undefined, modelRegistry: resolvedRegistry }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }), abort: async () => {}, dispose: async () => {} }; } } };
+  const agent = { transport: { id: "local", async createSession(value) { return { reference: { transport: "local", sessionId: "session", locator: { sessionFile } }, getState: () => ({ model: value.model, tools: value.tools }), getHerdrModelContext: () => ({ model: undefined, modelRegistry: resolvedRegistry }), getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }), abort: async () => {}, dispose: async () => {} }; } } };
   const controller = new AbortController();
   herdr.agentSetupHooks.fullyInspectable.setup(agent, { identity: { structuralPath: ["review"], parentBreadcrumb: "flow", callSite: "agent", occurrence: 1 }, run: { runId: "run", workflow: { name: "flow" } }, signal: controller.signal });
   const prepared = { cwd: "/repo", model: { provider: "inline-only", model: "inline-model" }, tools: [], customTools: [tool], initialPrompt: "work", sessionLabel: "flow:review", piRuntime };


### PR DESCRIPTION
## Context

Fully inspectable mode was effectively non-functional end to end. Agent tabs briefly appeared in Herdr and then closed, while child sessions could lose the original task prompt and fall back to a generic continuation message.

## Summary

- materialize fresh Pi session files before transferring session ownership to Herdr
- recognize Herdr-normalized Pi processes reported as `argv0: "pi"`
- tolerate transient process-reporting gaps before considering a Herdr pane exited
- add regression coverage for session materialization and process monitoring

## Root cause

Fresh workflow sessions could be handed off before their session file existed. The child Pi process would therefore start without the original prompt and terminate early.

Additionally, Herdr can normalize a running Pi process as `{ name: "node", argv0: "pi" }`. The pane monitor did not recognize this representation and incorrectly closed an active agent tab.

## Evidence of the fix

The screenshot below shows the real Herdr E2E after applying these changes. The fully inspectable child agent remains visible and running in its dedicated Herdr tab while executing the original workflow prompt.

<img width="2880" height="1800" alt="piewf-herdr-e2e-final" src="https://github.com/user-attachments/assets/38fde103-6f3e-4b2a-a0ee-438dd72e1654" />


## Verification

- Core Herdr tests: 10/10 passed
- `@piewf/herdr` tests: 29/29 passed
- Core and Herdr extension lint passed
- `git diff --check` passed
- Real Herdr E2E completed successfully:
  - the child agent remained visible with status `working`
  - the original prompt reached the child session
  - the child executed `sleep 30`
  - the workflow completed in 43 seconds
  - final result: `E2E_HERDR_OK`
