### PR TITLE
URGENT: Fix v5.8.0 Pi startup failure when Herdr is installed

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist/src",
+    "dist/subagents",
     "dist/trajectory",
     "src",
     "starter",

--- a/packages/core/test/workspace-layout.test.mjs
+++ b/packages/core/test/workspace-layout.test.mjs
@@ -10,6 +10,11 @@ const repositoryRoot = resolve(coreRoot, "../..");
 const cliRoot = resolve(repositoryRoot, "packages/cli");
 const readPackage = (path) => JSON.parse(readFileSync(path, "utf8"));
 
+test("the published core package includes compiled subagents", () => {
+  const core = readPackage(resolve(coreRoot, "package.json"));
+  assert.ok(core.files.includes("dist/subagents"));
+});
+
 test("the repository keeps the public package in the core workspace", () => {
   const root = readPackage(resolve(repositoryRoot, "package.json"));
   const core = readPackage(resolve(coreRoot, "package.json"));
@@ -30,7 +35,8 @@ test("the repository keeps the public package in the core workspace", () => {
     "./budget": "./dist/src/budget.js",
     "./validation": "./dist/src/validation.js",
     "./registry": "./dist/src/registry.js",
-    "./runtime": "./dist/src/runtime/index.js"
+    "./runtime": "./dist/src/runtime/index.js",
+    "./trajectory": "./dist/trajectory/index.js"
   });
   assert.equal(core.bin, undefined);
   assert.ok(core.files.includes("starter"));


### PR DESCRIPTION
## Impact

In v5.8.0, Pi fails to load `@piewf/herdr` at startup with:

> Cannot find module '../subagents/src/contracts.js'

This prevents the Herdr extension from loading and affects every Pi startup where the extension is enabled.

## Root cause

The core build emits runtime imports from `dist/src/trajectory.js` to files under `dist/subagents`, including:

```js
../subagents/src/contracts.js
```

TypeScript correctly generates those files, but `packages/core/package.json` did not include `dist/subagents` in its `files` allowlist. Consequently, npm omitted the compiled subagent modules from the published tarball.

Local builds and tests did not expose the issue because `dist/subagents` exists in the workspace before packaging.

## Fix

- Include `dist/subagents` in the published core package.
- Add a regression assertion covering the package allowlist.
- Update the stale layout expectation for the existing `./trajectory` export.

## Verification

- `npm run test:layout --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `npm run lint --workspace=packages/core`
- Created production tarballs for core and Herdr.
- Installed both tarballs into an isolated production environment.
- Started a real Pi process and loaded every declared core extension entrypoint plus the installed Herdr extension.
- Confirmed that Pi starts without extension-loading or module-resolution errors.

## Recommended follow-up

As a second pass, the release pipeline should add:

1. **Installed-package Pi smoke tests**
   - Build the actual npm tarballs.
   - Install them into a clean production environment.
   - Start a real Pi process against the installed packages.
   - Load every declared `pi.extensions` entrypoint and dependent extension such as Herdr.
   - Fail on any extension-loading error.

   A bare Node import is not sufficient because it does not exercise Pi's extension loader, peer-module resolution, or package discovery behavior.

2. **Tarball integrity tests**
   - Assert that every `exports` target exists in the tarball.
   - Assert that every declared `pi.extensions` entrypoint exists.
   - Verify that relative runtime imports from published JavaScript resolve to files contained in the tarball.

The existing `npm pack --dry-run --json` step only prints package contents. It succeeds even when required runtime files are missing, so its output should be asserted rather than inspected manually.
