### PR TITLE
test(release): gate publishing on installed-tarball Pi smoke tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,22 +39,21 @@ jobs:
         run: npm ci
       - name: Run checks
         run: npm run check
-      - name: Inspect package contents
-        run: |
-          npm pack --dry-run --json --workspace=packages/core
-          npm pack --dry-run --json --workspace=packages/cli
-          npm pack --dry-run --json --workspace=packages/extensions/herdr
+      - name: Verify package artifacts
+        run: npm run test:packages -- "$RUNNER_TEMP/piewf-packages"
       - name: Publish missing packages
         run: |
           publish() {
             workspace=$1
             name=$(node -p "require('./$workspace/package.json').name")
             version=$(node -p "require('./$workspace/package.json').version")
+            filename="${name#@}"
+            filename="${filename/\//-}-$version.tgz"
             if npm view "$name@$version" version >/dev/null 2>&1; then
               echo "$name@$version is already published"
             else
               case "$version" in *-*) tag=next;; *) tag=latest;; esac
-              (cd "$workspace" && npm publish --access public --tag "$tag")
+              npm publish "$RUNNER_TEMP/piewf-packages/$filename" --access public --tag "$tag"
             fi
           }
           publish packages/core

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ export default tseslint.config(
     rules: { "@typescript-eslint/require-await": "off" },
   },
   {
-    files: ["packages/core/test/**/*.mjs", "packages/core/subagents/**/*.mjs", "packages/extensions/herdr/**/*.js", "packages/extensions/herdr/**/*.mjs"],
+    files: ["scripts/**/*.mjs", "packages/core/test/**/*.mjs", "packages/core/subagents/**/*.mjs", "packages/extensions/herdr/**/*.js", "packages/extensions/herdr/**/*.mjs"],
     ...tseslint.configs.disableTypeChecked,
     languageOptions: {
       parserOptions: { project: false, projectService: false },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "scripts": {
     "build": "npm run build --workspace=packages/core && npm run build --workspace=packages/cli && npm run build --workspace=packages/extensions/herdr",
     "inspect": "npm run inspect --workspace=packages/cli",
-    "lint": "npm run lint --workspace=packages/core && npm run lint --workspace=packages/cli && npm run lint --workspace=packages/extensions/herdr",
+    "lint": "eslint scripts/verify-packed-packages.mjs && npm run lint --workspace=packages/core && npm run lint --workspace=packages/cli && npm run lint --workspace=packages/extensions/herdr",
     "test": "npm run test --workspace=packages/core && npm run test --workspace=packages/cli && npm run test --workspace=packages/extensions/herdr && npm run test:template",
     "test:run": "npm run test:run --workspace=packages/core && npm run test:herdr --workspace=packages/core && npm run test:run --workspace=packages/cli",
     "test:template": "node --test --test-timeout=10000 --test-force-exit packages/core/examples/workflow-extension-template/extension.test.mjs",
+    "test:packages": "node scripts/verify-packed-packages.mjs",
     "acceptance": "npm run acceptance --workspace=packages/core",
     "docs:check": "node scripts/check-docs.mjs",
     "check": "npm run build && npm run lint && npm test && npm run docs:check",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist/src",
+    "dist/subagents",
     "dist/trajectory",
     "src",
     "starter",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,8 @@
     "dist/src",
     "dist/subagents",
     "dist/trajectory",
+    "!dist/**/test/**",
+    "!dist/**/*.test.*",
     "src",
     "starter",
     "trajectory/index.ts",

--- a/packages/core/test/workspace-layout.test.mjs
+++ b/packages/core/test/workspace-layout.test.mjs
@@ -41,6 +41,8 @@ test("the repository keeps the public package in the core workspace", () => {
   assert.equal(core.bin, undefined);
   assert.ok(core.files.includes("starter"));
   assert.ok(core.files.includes("dist/trajectory"));
+  assert.ok(core.files.includes("!dist/**/test/**"));
+  assert.ok(core.files.includes("!dist/**/*.test.*"));
   assert.ok(core.files.includes("trajectory/index.ts"));
   assert.ok(core.files.includes("trajectory/src"));
   assert.ok(core.files.includes("subagents/index.ts"));

--- a/packages/core/test/workspace-layout.test.mjs
+++ b/packages/core/test/workspace-layout.test.mjs
@@ -10,6 +10,11 @@ const repositoryRoot = resolve(coreRoot, "../..");
 const cliRoot = resolve(repositoryRoot, "packages/cli");
 const readPackage = (path) => JSON.parse(readFileSync(path, "utf8"));
 
+test("the published core package includes compiled subagents", () => {
+  const core = readPackage(resolve(coreRoot, "package.json"));
+  assert.ok(core.files.includes("dist/subagents"));
+});
+
 test("the repository keeps the public package in the core workspace", () => {
   const root = readPackage(resolve(repositoryRoot, "package.json"));
   const core = readPackage(resolve(coreRoot, "package.json"));
@@ -30,7 +35,8 @@ test("the repository keeps the public package in the core workspace", () => {
     "./budget": "./dist/src/budget.js",
     "./validation": "./dist/src/validation.js",
     "./registry": "./dist/src/registry.js",
-    "./runtime": "./dist/src/runtime/index.js"
+    "./runtime": "./dist/src/runtime/index.js",
+    "./trajectory": "./dist/trajectory/index.js"
   });
   assert.equal(core.bin, undefined);
   assert.ok(core.files.includes("starter"));

--- a/scripts/verify-packed-packages.mjs
+++ b/scripts/verify-packed-packages.mjs
@@ -1,0 +1,91 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "acorn";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const work = mkdtempSync(resolve(tmpdir(), "piewf-packages-"));
+const output = process.argv[2] ? resolve(process.argv[2]) : resolve(work, "tarballs");
+const agentRoot = resolve(work, "agent");
+const installRoot = resolve(agentRoot, "npm");
+const workspaces = ["packages/core", "packages/cli", "packages/extensions/herdr"];
+
+function json(path) { return JSON.parse(readFileSync(path, "utf8")); }
+function packagePath(base, name) { return resolve(base, "node_modules", ...name.split("/")); }
+function tarballName({ name, version }) { return `${name.replace(/^@/, "").replaceAll("/", "-")}-${version}.tgz`; }
+function files(path) {
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) => {
+    const target = resolve(path, entry.name);
+    return entry.isDirectory() ? files(target) : [target];
+  });
+}
+function strings(value) {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap(strings);
+  if (value && typeof value === "object") return Object.values(value).flatMap(strings);
+  return [];
+}
+function filePathHasTestDirectory(path) { return path.split(/[\\/]/).includes("test"); }
+function relativeImports(source) {
+  const imports = [];
+  const visit = (value) => {
+    if (!value || typeof value !== "object") return;
+    if ((value.type === "ImportDeclaration" || value.type === "ExportNamedDeclaration" || value.type === "ExportAllDeclaration") && typeof value.source?.value === "string") imports.push(value.source.value);
+    if (value.type === "ImportExpression" && typeof value.source?.value === "string") imports.push(value.source.value);
+    for (const child of Object.values(value)) {
+      if (!child || typeof child !== "object") continue;
+      if (Array.isArray(child)) child.forEach(visit);
+      else visit(child);
+    }
+  };
+  visit(parse(source, { ecmaVersion: "latest", sourceType: "module" }));
+  return imports.filter((specifier) => specifier.startsWith("."));
+}
+
+try {
+  mkdirSync(output, { recursive: true });
+  const packages = workspaces.map((workspace) => ({ workspace, manifest: json(resolve(root, workspace, "package.json")) }));
+  for (const { workspace } of packages) execFileSync("npm", ["pack", `--workspace=${workspace}`, "--pack-destination", output], { cwd: root, stdio: "pipe", timeout: 120_000 });
+
+  const errors = [];
+  for (const { manifest } of packages) {
+    const tarball = resolve(output, tarballName(manifest));
+    const extracted = resolve(work, "extracted", manifest.name.replaceAll("/", "-"));
+    mkdirSync(extracted, { recursive: true });
+    execFileSync("tar", ["-xzf", tarball, "-C", extracted, "--strip-components=1"], { stdio: "pipe", timeout: 30_000 });
+    const packed = json(resolve(extracted, "package.json"));
+    const packedFiles = files(extracted);
+    const entrypoints = [packed.main, ...strings(packed.bin), ...strings(packed.exports), ...strings(packed.pi?.extensions)].filter((path) => typeof path === "string" && path.startsWith("./"));
+    for (const entrypoint of entrypoints) if (!existsSync(resolve(extracted, entrypoint))) errors.push(`${manifest.name}: missing entrypoint ${entrypoint}`);
+    for (const file of packedFiles.filter((path) => path.startsWith(resolve(extracted, "dist")) && (filePathHasTestDirectory(path.slice(extracted.length + 1)) || path.includes(".test.")))) errors.push(`${manifest.name}: published test artifact ${file.slice(extracted.length + 1)}`);
+    for (const file of packedFiles.filter((path) => path.endsWith(".js"))) {
+      for (const specifier of relativeImports(readFileSync(file, "utf8"))) if (!existsSync(resolve(dirname(file), specifier))) errors.push(`${manifest.name}: ${file.slice(extracted.length + 1)} imports missing ${specifier}`);
+    }
+  }
+  if (errors.length) throw new Error(errors.join("\n"));
+
+  const tarballs = packages.map(({ manifest }) => resolve(output, tarballName(manifest)));
+  execFileSync("npm", ["install", "--prefix", installRoot, "--ignore-scripts", "--omit=dev", "--legacy-peer-deps", ...tarballs], { stdio: "pipe", timeout: 120_000 });
+  execFileSync("npm", ["audit", "--prefix", installRoot, "--omit=dev"], { stdio: "pipe", timeout: 60_000 });
+
+  const localPackages = ["pi-extensible-workflows", "@piewf/herdr"].map((name) => packagePath(installRoot, name));
+  const extensionCount = localPackages.reduce((count, directory) => count + strings(json(resolve(directory, "package.json")).pi?.extensions).length, 0);
+  const pi = resolve(root, "node_modules/.bin/pi");
+  const herdrVariables = new Set(["HERDR_ENV", "HERDR_PANE_ID", "HERDR_SOCKET_PATH", "HERDR_TAB_ID", "HERDR_WORKSPACE_ID"]);
+  const env = { ...Object.fromEntries(Object.entries(process.env).filter(([name]) => !herdrVariables.has(name))), PI_CODING_AGENT_DIR: agentRoot, PI_OFFLINE: "1" };
+  for (const directory of localPackages) {
+    const installation = spawnSync(pi, ["install", directory], { cwd: work, encoding: "utf8", env, timeout: 30_000 });
+    if (installation.error) throw installation.error;
+    if (installation.status !== 0) throw new Error(`Pi local package installation failed (${String(installation.status)}):\n${installation.stdout ?? ""}${installation.stderr ?? ""}`);
+  }
+  const result = spawnSync(pi, ["--mode", "rpc"], { cwd: work, encoding: "utf8", env, input: "", timeout: 30_000 });
+  const outputText = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  if (result.error) throw result.error;
+  if (result.status !== 0 || /Failed to load extension|Cannot find module/.test(outputText)) throw new Error(`Pi package discovery smoke test failed (${String(result.status)}):\n${outputText}`);
+
+  process.stdout.write(`Package verification passed: ${packages.length} tarballs, ${localPackages.length} local Pi packages, and ${extensionCount} discovered extensions.\n`);
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Outcome

Adds a pre-release gate that validates the actual npm artifacts before the release workflow can publish them. The gate packs core, CLI, and Herdr, checks their contents, installs the packages in an isolated production layout, registers core and Herdr through `pi install <local-path>`, and starts Pi through normal settings-based package discovery.

This directly addresses the release gap exposed by #232: workspace tests could pass while a required runtime file was absent from the npm tarball.

Depends on #232. Until that PR is merged, this stacked PR also shows its prerequisite packaging commit; the diff will reduce to the release gate after #232 lands.

## Scope

Included:

- Validate package exports, binaries, and declared Pi extension entrypoints against extracted tarballs.
- Resolve relative JavaScript imports inside the packed artifacts.
- Reject compiled test artifacts under `dist`.
- Install the generated tarballs with production dependencies and run `npm audit`.
- Register the installed core and Herdr packages through Pi's local-path installation command.
- Start Pi without explicit extension flags and verify settings-based discovery of all five extension entrypoints.
- Publish the same tarballs that passed verification when the maintainer runs the release workflow.
- Keep future runtime artifacts included while excluding conventional compiled test paths through stable npm glob rules.

Not included:

- Publishing or triggering a release from this contributor branch.
- Adding the release gate to a separate pull-request CI workflow.
- Exercising the interactive TUI; RPC mode is used only so startup can terminate deterministically in automation.

## Impact and risk

- **Impact: Medium.** This changes the release gate for all three public packages and prevents incomplete artifacts from reaching npm.
- **Risk: Medium.** It crosses npm packaging, production dependency installation, Pi package installation and discovery, and GitHub Actions publishing. Local end-to-end evidence is strong, but the updated workflow has not yet run in the upstream release environment.

## Validation

Observed locally:

- `npm run test:packages` passed for three generated tarballs, two locally installed Pi packages, and five discovered extension entrypoints.
- Core and Herdr were registered through `pi install <local-path>`, producing normal package entries in isolated `settings.json`.
- `pi --mode rpc` then started without `-ne` or `-e` and discovered core, starter, Subagents, Trajectory, and Herdr without extension or module-resolution failures.
- Package entrypoint, relative-import, compiled-test exclusion, and production audit checks passed.
- `npm run test:layout --workspace=packages/core` passed all three layout checks.
- `npm run lint` passed across the repository.
- `.github/workflows/publish.yml` parsed successfully as YAML.

## Limitations

Pi's local-path installer registers directories rather than unpacking npm tarballs. The gate therefore production-installs the generated tarballs into the isolated Pi package layout first, then passes those installed package directories to `pi install`. This avoids a local npm registry while still exercising the formed artifacts, Pi's settings persistence, package discovery, and extension autoload.

## Operational considerations

- The release runner needs npm registry access for the isolated production install and audit, as it already does for installation and publishing.
- Each packaging, installation, audit, and Pi smoke phase has a finite timeout.
- Publishing remains controlled by the existing tag or manual release workflow and its maintainer credentials.
- The workflow publishes the verified `.tgz` files instead of repacking each workspace after verification.

## Reviewer attention

Please confirm that trusted npm publishing in the upstream environment accepts `npm publish <verified-tarball>` with the existing OIDC configuration. This is the remaining environment-specific uncertainty.
