### PR TITLE
fix(ci): skip Pages deployment in forks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,22 +5,31 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  pages: write
-  id-token: write
 concurrency:
   group: pages
   cancel-in-progress: true
 jobs:
-  deploy:
+  validate:
     runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Validate documentation
+        run: npm run docs:check
+  deploy:
+    needs: validate
+    if: github.repository == 'vekexasia/pi-extensible-workflows'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Validate documentation
-        run: npm run docs:check
       - name: Configure Pages
         uses: actions/configure-pages@v5
       - name: Upload Pages artifact


### PR DESCRIPTION
## Outcome

Documentation validation remains active on the workflow's existing `main` push and manual triggers, while Pages deployment now runs only in `vekexasia/pi-extensible-workflows` after validation succeeds.

In forks, the validation job still runs and the deployment job is reported as skipped, so the workflow succeeds when documentation is valid. Fork runs no longer request Pages permissions, enter the `github-pages` environment, upload a Pages artifact, or call the deployment action. This is a follow-up to #51.

## Impact and risk

- **Impact: Medium** — changes the bounded documentation CI/deployment process for the canonical repository and its forks. Canonical publishing behavior remains automatic from `main`; forks retain validation without attempting a deployment they cannot use.
- **Risk: Medium** — the workflow change is isolated and easy to revert, and its structure was validated locally. However, GitHub-hosted condition evaluation and the canonical Pages deployment path were not exercised end to end because doing so would require an eligible Actions run and could trigger a deployment.

## Evidence and validation

- `npm run docs:check` passes, covering 7 HTML pages and 8 required files.
- The workflow parses as YAML, and local assertions confirm that validation is unconditional, deployment depends on validation, the deployment job is guarded by the exact canonical repository name, and elevated permissions exist only on that job.
- `git diff --check` passes.
- The pre-change fork failure mode is visible in [this historical Actions run](https://github.com/marcoscale98/pi-extensible-workflows/actions/runs/32700591684): documentation validation succeeded, then Pages configuration failed. With this change, the deployment job is skipped before Pages configuration in forks.

## Limitations and operational notes

- No package publication or Pages deployment was triggered.
- No post-change GitHub-hosted run is available: feature-branch pushes do not match this workflow's triggers, and a manual run was intentionally avoided because the request excludes triggering deployments.
- Canonical deployment still depends on GitHub Pages being enabled and correctly configured for GitHub Actions. That environment-specific state cannot be verified from local checks.
- Rollback is a single workflow-file revert.