### PR TITLE
fix(core): keep workflow warnings out of model context

### DIFF
--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -178,9 +178,10 @@ function deliver(pi: WorkflowExtensionAPI, content: string): void {
   if (typeof pi.sendMessage !== "function") return;
   pi.sendMessage({ customType: "workflow", content, display: true }, { deliverAs: "followUp", triggerTurn: true });
 }
+const WORKFLOW_WARNING_ENTRY = "workflow-warning";
+interface WorkflowWarningEntry { message: string }
 function deliverWarning(pi: WorkflowExtensionAPI, content: string): void {
-  if (typeof pi.sendMessage !== "function") return;
-  pi.sendMessage({ customType: "workflow", content: `Warning: ${content}`, display: true }, { deliverAs: "steer" });
+  pi.appendEntry<WorkflowWarningEntry>(WORKFLOW_WARNING_ENTRY, { message: content });
 }
 
 type WorkflowEventSink = { emit: (name: string, payload: unknown) => unknown };
@@ -264,6 +265,10 @@ export default function workflowExtension(pi: WorkflowExtensionAPI, home?: strin
   registerEntryRenderer?.<WorkflowLogEntry>(WORKFLOW_LOG_ENTRY, (entry) => {
     const data = entry.data;
     return textBlock(data ? `Workflow ${data.workflowName}: ${data.message}` : "");
+  });
+  registerEntryRenderer?.<WorkflowWarningEntry>(WORKFLOW_WARNING_ENTRY, (entry) => {
+    const data = entry.data;
+    return textBlock(data ? `Warning: ${data.message}` : "");
   });
   let backgroundWidgetEnabled = true;
   try { backgroundWidgetEnabled = loadSettings(workflowSettingsPath(extensionAgentDir)).backgroundWidget ?? true; } catch { /* Keep the optional UI enabled; the launch path reports settings errors. */ }

--- a/packages/core/test/checkpoints-delivery.test.ts
+++ b/packages/core/test/checkpoints-delivery.test.ts
@@ -516,7 +516,7 @@ void test("background workflow logs persist and append capped TUI transcript ent
   let renderer: ((entry: { data?: LogData }, options: unknown, theme: unknown) => { render(width: number): string[] }) | undefined;
   workflowExtension(testExtensionApi({
     registerTool(tool: (typeof tools)[number]) { tools.push(tool); }, registerCommand() {}, on() {},
-    registerEntryRenderer(type: string, candidate: NonNullable<typeof renderer>) { assert.equal(type, "workflow-log"); renderer = candidate; },
+    registerEntryRenderer(type: string, candidate: NonNullable<typeof renderer>) { if (type === "workflow-log") renderer = candidate; },
     appendEntry(type: string, data: LogData) { entries.push({ type, data }); },
     getThinkingLevel: () => "medium" as const, getActiveTools: () => ["workflow"],
   }), home);

--- a/packages/core/test/configuration.test.ts
+++ b/packages/core/test/configuration.test.ts
@@ -251,9 +251,9 @@ void test("workflow extension wires the background widget from global settings",
     return { renderers, shortcuts };
   };
 
-  assert.deepEqual(install(undefined), { renderers: ["workflow-log", "piewf-run-receipt"], shortcuts: ["alt+o"] });
-  assert.deepEqual(install(JSON.stringify({ backgroundWidget: false })), { renderers: ["workflow-log"], shortcuts: [] });
-  assert.deepEqual(install("{"), { renderers: ["workflow-log", "piewf-run-receipt"], shortcuts: ["alt+o"] });
+  assert.deepEqual(install(undefined), { renderers: ["workflow-log", "workflow-warning", "piewf-run-receipt"], shortcuts: ["alt+o"] });
+  assert.deepEqual(install(JSON.stringify({ backgroundWidget: false })), { renderers: ["workflow-log", "workflow-warning"], shortcuts: [] });
+  assert.deepEqual(install("{"), { renderers: ["workflow-log", "workflow-warning", "piewf-run-receipt"], shortcuts: ["alt+o"] });
 });
 
 void test("composes trusted resource selectors and ignores untrusted project selectors", () => {

--- a/packages/core/test/workflow-host.test.ts
+++ b/packages/core/test/workflow-host.test.ts
@@ -214,6 +214,7 @@ void test("keeps unavailable role tool warnings out of model context", async () 
   const pi = testExtensionApi({
     registerTool(tool: (typeof tools)[number]) { tools.push(tool); }, registerCommand() {}, on() {},
     getThinkingLevel: () => "medium", getActiveTools: () => ["workflow", "read"],
+    registerEntryRenderer() {},
     sendMessage(message) { messages.push(message.content); },
   });
   workflowExtension({ ...pi, appendEntry(type, data) { entries.push({ type, data }); } }, home, async () => {}, testTransport(async (): Promise<TestPiSession> => ({

--- a/packages/core/test/workflow-host.test.ts
+++ b/packages/core/test/workflow-host.test.ts
@@ -202,6 +202,33 @@ void test("attributes dynamic alias cycles to the registering extension", async 
   await assert.rejects(execute("id", { name: "cycle", script: "return true;", foreground: true }, new AbortController().signal, undefined, context), (error: unknown) => error instanceof WorkflowError && error.code === "CONFIG_ERROR" && error.message.includes("Cycle policy"));
   loadingRegistry().freeze();
 });
+void test("keeps unavailable role tool warnings out of model context", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-warning-entry-"));
+  const agentDir = join(home, "agent");
+  const roleDirectory = join(agentDir, "pi-extensible-workflows", "roles");
+  mkdirSync(roleDirectory, { recursive: true });
+  writeFileSync(join(roleDirectory, "developer.md"), `---\ntools: ["!*", missing_tool]\n---\n`);
+  const tools: Array<{ name: string; execute: (...args: unknown[]) => Promise<unknown> }> = [];
+  const messages: string[] = [];
+  const entries: Array<{ type: string; data: unknown }> = [];
+  const pi = testExtensionApi({
+    registerTool(tool: (typeof tools)[number]) { tools.push(tool); }, registerCommand() {}, on() {},
+    getThinkingLevel: () => "medium", getActiveTools: () => ["workflow", "read"],
+    sendMessage(message) { messages.push(message.content); },
+  });
+  workflowExtension({ ...pi, appendEntry(type, data) { entries.push({ type, data }); } }, home, async () => {}, testTransport(async (): Promise<TestPiSession> => ({
+    sessionId: "warning-entry-agent", sessionFile: "/sessions/warning-entry-agent.jsonl",
+    messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0 }),
+    prompt: async () => {}, steer: async () => {}, dispose() {},
+  })), agentDir);
+  const execute = tools.find(({ name }) => name === "workflow")?.execute;
+  assert.ok(execute);
+  await execute("warning-entry", { name: "warning-entry", script: `return await agent("work", { role: "developer" });`, foreground: true }, new AbortController().signal, undefined, { cwd: home, model: { provider: "openai", id: "gpt" }, modelRegistry: { getAll: () => [{ provider: "openai", id: "gpt" }], getAvailable: () => [{ provider: "openai", id: "gpt" }] }, sessionManager: { getSessionId: () => "session" } });
+  assert.deepEqual(messages, []);
+  assert.deepEqual(entries, [{ type: "workflow-warning", data: { message: "Tool not available in this session for role developer: missing_tool. The agent runs without it." } }]);
+  loadingRegistry().freeze();
+});
 const valid = `phase("check"); agent("review", { role: "reviewer" }); agent("custom", { model: "openai/gpt:medium", tools: ["read"] });`;
 void test("workflow call preview summarizes inline scripts safely", () => {
   const preview = formatWorkflowPreview({ script: valid, name: "review", description: "Review code" });


### PR DESCRIPTION
## Summary
- store workflow resource warnings as custom UI entries instead of steering messages
- render those entries without adding them to the model conversation
- add a regression test for unavailable role tools

## Verification
- `npm run build --workspace=packages/core`
- `npx eslint packages/core/src/host.ts packages/core/test/workflow-host.test.ts`
- `node --expose-gc --test --test-concurrency=1 --test-timeout=120000 --test-force-exit packages/core/dist/test/workflow-host.test.js` (26/26 passed)