### PR TITLE
fix(core): prevent stopped registered workflows from crashing Pi

### DIFF
--- a/packages/core/src/host-runtime.ts
+++ b/packages/core/src/host-runtime.ts
@@ -277,7 +277,15 @@ export function withWorkflowFunctions(bridge: WorkflowBridge, store: RunStore, r
     const worktreeOwner = identity.worktreeOwner;
     const replayed = await store.replay(path);
     let stored: JsonValue | undefined;
-    const sideEffects: Promise<void>[] = [];
+    type SideEffectOutcome = { ok: true } | { ok: false; error: unknown };
+    const sideEffects: Array<Promise<SideEffectOutcome>> = [];
+    const ownSideEffect = (effect: () => void | Promise<void>): void => {
+      try {
+        sideEffects.push(Promise.resolve(effect()).then(() => ({ ok: true as const }), (error: unknown) => ({ ok: false as const, error })));
+      } catch (error) {
+        sideEffects.push(Promise.resolve({ ok: false as const, error }));
+      }
+    };
     const parentBreadcrumb = breadcrumb ?? functionBreadcrumb(name, identity.occurrence);
     const context: WorkflowFunctionContext = {
       run: runContext,
@@ -325,11 +333,13 @@ export function withWorkflowFunctions(bridge: WorkflowBridge, store: RunStore, r
         if (!bridge.checkpoint || !object(args[0]) || !jsonValue(args[0])) fail("INTERNAL_ERROR", "No checkpoint bridge is available");
         return bridge.checkpoint(args[0], signal);
       },
-      phase: (name: string) => { sideEffects.push(Promise.resolve(bridge.phase?.(name))); },
-      log: (message: string) => { sideEffects.push(Promise.resolve(bridge.log?.(message))); },
+      phase: (name: string) => { ownSideEffect(() => bridge.phase?.(name)); },
+      log: (message: string) => { ownSideEffect(() => bridge.log?.(message)); },
     };
     const result = await inheritedHostAgentPath.run([...structuralPath], async () => registry.invokeFunction(name, input, context, path, { get: () => replayed?.value, put: (_path, value) => { stored = value; } }));
-    await Promise.all(sideEffects);
+    const outcomes = await Promise.all(sideEffects);
+    const sideEffectError = outcomes.find((outcome) => !outcome.ok);
+    if (sideEffectError) throw sideEffectError.error;
     if (!replayed) await store.complete(path, stored ?? result);
     return result;
   };

--- a/packages/core/src/host-runtime.ts
+++ b/packages/core/src/host-runtime.ts
@@ -277,14 +277,17 @@ export function withWorkflowFunctions(bridge: WorkflowBridge, store: RunStore, r
     const worktreeOwner = identity.worktreeOwner;
     const replayed = await store.replay(path);
     let stored: JsonValue | undefined;
-    type SideEffectOutcome = { ok: true } | { ok: false; error: unknown };
-    const sideEffects: Array<Promise<SideEffectOutcome>> = [];
+    const sideEffects: Promise<void>[] = [];
     const ownSideEffect = (effect: () => void | Promise<void>): void => {
+      let sideEffect: Promise<void>;
       try {
-        sideEffects.push(Promise.resolve(effect()).then(() => ({ ok: true as const }), (error: unknown) => ({ ok: false as const, error })));
+        sideEffect = Promise.resolve(effect());
       } catch (error) {
-        sideEffects.push(Promise.resolve({ ok: false as const, error }));
+        sideEffect = Promise.resolve().then(() => { throw error; });
       }
+      sideEffects.push(sideEffect);
+      // Own rejection immediately; Promise.all below still propagates it after the function completes.
+      void sideEffect.catch(() => undefined);
     };
     const parentBreadcrumb = breadcrumb ?? functionBreadcrumb(name, identity.occurrence);
     const context: WorkflowFunctionContext = {
@@ -337,9 +340,7 @@ export function withWorkflowFunctions(bridge: WorkflowBridge, store: RunStore, r
       log: (message: string) => { ownSideEffect(() => bridge.log?.(message)); },
     };
     const result = await inheritedHostAgentPath.run([...structuralPath], async () => registry.invokeFunction(name, input, context, path, { get: () => replayed?.value, put: (_path, value) => { stored = value; } }));
-    const outcomes = await Promise.all(sideEffects);
-    const sideEffectError = outcomes.find((outcome) => !outcome.ok);
-    if (sideEffectError) throw sideEffectError.error;
+    await Promise.all(sideEffects);
     if (!replayed) await store.complete(path, stored ?? result);
     return result;
   };

--- a/packages/core/test/alias-extensions.test.ts
+++ b/packages/core/test/alias-extensions.test.ts
@@ -279,6 +279,105 @@ void test("registered function context.invoke validates nested calls and replays
   await assert.rejects(context.invoke("leaf", { value: 1 }), (error: unknown) => error instanceof WorkflowError && error.code === "RESULT_INVALID");
   await assert.rejects(context.invoke("missing", {}), (error: unknown) => error instanceof WorkflowError && error.code === "MISSING_WORKFLOW");
 });
+void test("host owns phase and log rejections while registered functions continue", async () => {
+  const registry = new WorkflowRegistry();
+  let markStarted!: () => void;
+  let release!: () => void;
+  const started = new Promise<void>((resolve) => { markStarted = resolve; });
+  const continueFunction = new Promise<void>((resolve) => { release = resolve; });
+  const phaseError = new Error("phase failed");
+  const logError = new Error("log failed");
+  let resolvePhase!: () => void;
+  let rejectPhase!: (error: unknown) => void;
+  const phaseRejection = new Promise<void>((resolve, reject) => { resolvePhase = resolve; rejectPhase = reject; });
+  let resolveLog!: () => void;
+  let rejectLog!: (error: unknown) => void;
+  const logRejection = new Promise<void>((resolve, reject) => { resolveLog = resolve; rejectLog = reject; });
+  registry.register({ version: "1.0.0", headline: "Side effects", functions: {
+    sideEffects: { description: "Side effects", input: { type: "object", additionalProperties: false }, output: { type: "object", additionalProperties: false }, run: async (_input, context) => { context.phase("phase"); context.log("message"); markStarted(); await continueFunction; return {}; } },
+  } });
+  const store = { replay: async () => undefined, complete: async () => {} } as unknown as RunStore;
+  const controller = new AbortController();
+  const wrapped = withWorkflowFunctions({ phase: () => phaseRejection, log: () => logRejection }, store, workflowRunContext("/repo", "session", "run", { name: "side-effects" }, null, controller.signal), registry);
+  if (!wrapped.function) throw new Error("Missing function bridge");
+  const events: string[] = [];
+  const onUnhandled = () => { events.push("unhandledRejection"); };
+  const onHandled = () => { events.push("rejectionHandled"); };
+  const drainEventLoop = async (): Promise<void> => {
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+  };
+  process.on("unhandledRejection", onUnhandled);
+  process.on("rejectionHandled", onHandled);
+  try {
+    const invocation = wrapped.function("sideEffects", {}, controller.signal, { path: "function/sideEffects/1", structuralPath: [], occurrence: 1 });
+    const rejection = assert.rejects(invocation, (error: unknown) => error === phaseError);
+    await started;
+    rejectPhase(phaseError);
+    rejectLog(logError);
+    await drainEventLoop();
+    assert.deepEqual(events, []);
+    release();
+    await rejection;
+    await drainEventLoop();
+    assert.deepEqual(events, []);
+  } finally {
+    markStarted();
+    release();
+    resolvePhase();
+    resolveLog();
+    process.off("unhandledRejection", onUnhandled);
+    process.off("rejectionHandled", onHandled);
+  }
+});
+void test("host owns phase and log rejections when registered functions throw", async () => {
+  const registry = new WorkflowRegistry();
+  let markThrown!: () => void;
+  const thrown = new Promise<void>((resolve) => { markThrown = resolve; });
+  const phaseError = new Error("phase failed");
+  const logError = new Error("log failed");
+  const functionError = new Error("function failed");
+  let resolvePhase!: () => void;
+  let rejectPhase!: (error: unknown) => void;
+  const phaseRejection = new Promise<void>((resolve, reject) => { resolvePhase = resolve; rejectPhase = reject; });
+  let resolveLog!: () => void;
+  let rejectLog!: (error: unknown) => void;
+  const logRejection = new Promise<void>((resolve, reject) => { resolveLog = resolve; rejectLog = reject; });
+  registry.register({ version: "1.0.0", headline: "Throwing side effects", functions: {
+    failed: { description: "Failed function", input: { type: "object", additionalProperties: false }, output: { type: "object", additionalProperties: false }, run: (_input, context) => { context.phase("phase"); context.log("message"); try { throw functionError; } finally { markThrown(); } } },
+  } });
+  const store = { replay: async () => undefined, complete: async () => {} } as unknown as RunStore;
+  const controller = new AbortController();
+  const wrapped = withWorkflowFunctions({ phase: () => phaseRejection, log: () => logRejection }, store, workflowRunContext("/repo", "session", "run", { name: "throwing-side-effects" }, null, controller.signal), registry);
+  if (!wrapped.function) throw new Error("Missing function bridge");
+  const events: string[] = [];
+  const onUnhandled = () => { events.push("unhandledRejection"); };
+  const onHandled = () => { events.push("rejectionHandled"); };
+  const drainEventLoop = async (): Promise<void> => {
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+  };
+  process.on("unhandledRejection", onUnhandled);
+  process.on("rejectionHandled", onHandled);
+  try {
+    const invocation = wrapped.function("failed", {}, controller.signal, { path: "function/failed/1", structuralPath: [], occurrence: 1 });
+    const rejection = assert.rejects(invocation, (error: unknown) => error === functionError);
+    await thrown;
+    rejectPhase(phaseError);
+    rejectLog(logError);
+    await rejection;
+    await drainEventLoop();
+    assert.deepEqual(events, []);
+    await drainEventLoop();
+    assert.deepEqual(events, []);
+  } finally {
+    markThrown();
+    resolvePhase();
+    resolveLog();
+    process.off("unhandledRejection", onUnhandled);
+    process.off("rejectionHandled", onHandled);
+  }
+});
 void test("host composes occurrence-aware nested function breadcrumbs", async () => {
   const registry = new WorkflowRegistry();
   registry.register({

--- a/packages/core/test/alias-extensions.test.ts
+++ b/packages/core/test/alias-extensions.test.ts
@@ -279,26 +279,24 @@ void test("registered function context.invoke validates nested calls and replays
   await assert.rejects(context.invoke("leaf", { value: 1 }), (error: unknown) => error instanceof WorkflowError && error.code === "RESULT_INVALID");
   await assert.rejects(context.invoke("missing", {}), (error: unknown) => error instanceof WorkflowError && error.code === "MISSING_WORKFLOW");
 });
-void test("host owns phase and log rejections while registered functions continue", async () => {
+void test("host fails fast on phase rejection without waiting for a pending log", async () => {
   const registry = new WorkflowRegistry();
   let markStarted!: () => void;
   let release!: () => void;
   const started = new Promise<void>((resolve) => { markStarted = resolve; });
   const continueFunction = new Promise<void>((resolve) => { release = resolve; });
   const phaseError = new Error("phase failed");
-  const logError = new Error("log failed");
   let resolvePhase!: () => void;
   let rejectPhase!: (error: unknown) => void;
   const phaseRejection = new Promise<void>((resolve, reject) => { resolvePhase = resolve; rejectPhase = reject; });
   let resolveLog!: () => void;
-  let rejectLog!: (error: unknown) => void;
-  const logRejection = new Promise<void>((resolve, reject) => { resolveLog = resolve; rejectLog = reject; });
+  const pendingLog = new Promise<void>((resolve) => { resolveLog = resolve; });
   registry.register({ version: "1.0.0", headline: "Side effects", functions: {
     sideEffects: { description: "Side effects", input: { type: "object", additionalProperties: false }, output: { type: "object", additionalProperties: false }, run: async (_input, context) => { context.phase("phase"); context.log("message"); markStarted(); await continueFunction; return {}; } },
   } });
   const store = { replay: async () => undefined, complete: async () => {} } as unknown as RunStore;
   const controller = new AbortController();
-  const wrapped = withWorkflowFunctions({ phase: () => phaseRejection, log: () => logRejection }, store, workflowRunContext("/repo", "session", "run", { name: "side-effects" }, null, controller.signal), registry);
+  const wrapped = withWorkflowFunctions({ phase: () => phaseRejection, log: () => pendingLog }, store, workflowRunContext("/repo", "session", "run", { name: "side-effects" }, null, controller.signal), registry);
   if (!wrapped.function) throw new Error("Missing function bridge");
   const events: string[] = [];
   const onUnhandled = () => { events.push("unhandledRejection"); };
@@ -311,13 +309,16 @@ void test("host owns phase and log rejections while registered functions continu
   process.on("rejectionHandled", onHandled);
   try {
     const invocation = wrapped.function("sideEffects", {}, controller.signal, { path: "function/sideEffects/1", structuralPath: [], occurrence: 1 });
-    const rejection = assert.rejects(invocation, (error: unknown) => error === phaseError);
+    let settled = false;
+    const rejection = assert.rejects(invocation, (error: unknown) => error === phaseError).then(() => { settled = true; });
     await started;
     rejectPhase(phaseError);
-    rejectLog(logError);
     await drainEventLoop();
     assert.deepEqual(events, []);
     release();
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    assert.equal(settled, true);
+    resolveLog();
     await rejection;
     await drainEventLoop();
     assert.deepEqual(events, []);


### PR DESCRIPTION
## Summary

- immediately own registered-function `phase()` and `log()` bridge rejections as explicit outcomes
- preserve the void API and immediate side-effect ordering, then rethrow the original failure at the existing invocation boundary
- add regressions for functions that continue after side-effect rejection and functions that throw while side effects are still in flight

Fixes #248.

## Testing

- `npm run build --workspace=packages/core`
- `npm run lint --workspace=packages/core`
- `TEST_FILES='dist/test/alias-extensions.test.js' npm run test:run --workspace=packages/core`
