### PR TITLE
fix(core): abort bridge work when workflow fails

### DIFF
--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -523,7 +523,7 @@ export function runWorkflow(script: string, args: JsonValue = null, bridge: Work
         const message = parsed;
         if (message.type === "heartbeat") { lastHeartbeatAt = performance.now(); return; }
         if (message.type === "result") { encoded(message.value); finish(); resolve(message.value); return; }
-        if (message.type === "error") { finish(); reject(workflowErrorFromWorker(message.error)); return; }
+        if (message.type === "error") { controller.abort(); finish(); reject(workflowErrorFromWorker(message.error)); return; }
         if (message.type === "rpc") void handleRpc(message.id, message.method, message.args);
       } catch (error) { stop(error instanceof WorkflowError ? error.code : "INTERNAL_ERROR", errorText(error)); }
     });

--- a/packages/core/test/workflow-runtime.test.ts
+++ b/packages/core/test/workflow-runtime.test.ts
@@ -469,6 +469,24 @@ void test("workflow cancellation reaches an active top-level scheduler agent", a
   assert.deepEqual(scheduler.snapshot().map(({ state }) => state), ["cancelled"]);
 });
 
+void test("workflow failure aborts in-flight bridge work", async () => {
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => { markStarted = resolve; });
+  let markAborted!: () => void;
+  const aborted = new Promise<void>((resolve) => { markAborted = resolve; });
+  const run = runWorkflow(`await Promise.all([shell("wait"), Promise.reject(new Error("boom"))]);`, null, {
+    shell: async (_command, _options, signal) => {
+      markStarted();
+      await new Promise<void>((resolve) => { signal.addEventListener("abort", () => { resolve(); }, { once: true }); });
+      markAborted();
+      throw new WorkflowError("CANCELLED", "cancelled");
+    },
+  });
+  await started;
+  await assert.rejects(run.result, /boom/);
+  await aborted;
+});
+
 void test("worker watchdog terminates a synchronous heartbeat stall after five seconds", { timeout: 7000 }, async () => {
   const run = runWorkflow(`export const meta={name:'x',description:'x'}; while(true){}`);
   const started = performance.now();


### PR DESCRIPTION
## Summary

- abort the host bridge when the workflow worker reports a terminal error
- prevent in-flight shell and agent work from continuing after the workflow is marked failed
- add regression coverage for concurrent bridge work during worker failure

## Verification

- `npm run build --workspace=packages/core`
- `TEST_FILES='dist/test/workflow-runtime.test.js' npm run test:run --workspace=packages/core`
- `npm run lint --workspace=packages/core`

`npm run check` reaches an unrelated existing CLI test failure: the portable bundle installation fixture cannot resolve `typebox` from the reconstructed installed layout.
