### PR TITLE
fix(core): truncate host text blocks by display width

### DIFF
--- a/packages/core/src/host-view.ts
+++ b/packages/core/src/host-view.ts
@@ -1,4 +1,5 @@
 import { keyHint, truncateToVisualLines, type Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { type AwaitingCheckpoint, type PersistedRun, type RunStore, type WorktreeReference } from "./persistence.js";
 import { budgetUsage } from "./budget.js";
 import { formatCost } from "./background-widget.js";
@@ -177,7 +178,7 @@ const WORKFLOW_PROGRESS_REFRESH_MS = 1_000;
 export function textBlock(text: string) {
   return {
     render(width: number) {
-      return text.split("\n").map((line) => line.length <= width ? line : `${line.slice(0, Math.max(0, width - 1))}…`);
+      return text.split("\n").map((line) => truncateToWidth(line, Math.max(1, width), "…"));
     },
     invalidate() {},
   };

--- a/packages/core/test/progress.test.ts
+++ b/packages/core/test/progress.test.ts
@@ -3,9 +3,10 @@ import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { contextualWorkflowAction, testExtensionApi, waitForIssue105 } from "./support.js";
 import workflowExtension, { createLaunchSnapshot, DEFAULT_SETTINGS, formatAgentDetail, formatCost, formatNavigatorDashboard, formatNavigatorRun, formatWorkflowPhaseDashboard, formatWorkflowProgress, mergeBudget, RunStore, truncateWorkflowProgress, WORKFLOW_AGENT_STALL_THRESHOLD_MS, type AgentRecord, type PersistedRun } from "../src/index.js";
-import { navigatorRunLabels } from "../src/host-view.js";
+import { navigatorRunLabels, textBlock } from "../src/host-view.js";
 import { listRunIds } from "../src/persistence.js";
 import { testTransport, type TestPiSession, type TestPiSessionEvent } from "./test-transport.js";
 
@@ -16,6 +17,13 @@ function makeAgent(overrides: Partial<AgentRecord> = {}): AgentRecord {
 function makeRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
   return { id: "run", workflowName: "test", cwd: "/repo", sessionId: "session", state: "running", agents: [], agentSessions: [], ...overrides };
 }
+
+void test("text blocks truncate wide characters by visible width", () => {
+  const width = 5;
+  const rendered = textBlock("工作流消息\nplain text").render(width);
+
+  assert.deepEqual(rendered.map((line) => visibleWidth(line)), [width, width]);
+});
 
 void test("workflow progress warns after ten minutes of agent silence and resets on events", () => {
   const now = 12 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

- truncate host text blocks by terminal display width instead of JavaScript string length
- add regression coverage for CJK output

## Verification

- `npm run build --workspace=packages/core`
- `node --test --test-timeout=120000 --test-force-exit packages/core/dist/test/progress.test.js` (29 passed)
- `npm run lint --workspace=packages/core`
