### PR TITLE
fix(cli): preserve trust override for bundle export

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -553,7 +553,7 @@ async function runWorkflowCli(rawArgs: readonly string[], options: WorkflowIo): 
 async function exportWorkflowCli(rawArgs: readonly string[], options: WorkflowIo): Promise<number> {
   const parsed = stripTrustOptions(rawArgs);
   const args = parsed.args;
-  if (args.includes("--bundle")) return bundleWorkflowCli(args.filter((arg) => arg !== "--bundle"), options);
+  if (args.includes("--bundle")) return bundleWorkflowCli(args.filter((arg) => arg !== "--bundle"), { ...options, ...(parsed.trustOverride !== undefined ? { trustOverride: parsed.trustOverride } : {}) });
   if (!args.length || args[0] === "--help" || args[0] === "-h") { options.write(exportUsage()); return args.length ? 0 : 1; }
   const workflowName = requiredArg(args, 0);
   return withWorkflowRuntime({ ...options, ...(parsed.trustOverride !== undefined ? { trustOverride: parsed.trustOverride } : {}) }, async (runtime) => {

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -559,6 +559,15 @@ void test("export refuses existing files and replaces them only with --force", a
   assert.equal(await runCli(["export", "cliEcho", "--output", directory, "--force"], { cwd: paths.cwd, agentDir: paths.agentDir, stderr: () => {} }), 1);
   assert.equal(lstatSync(directory).isDirectory(), true);
 });
+void test("export bundle forwards explicit trust override", async () => {
+  registerCliExtension();
+  const paths = fixture();
+  writeFileSync(join(paths.cwd, ".pi", "settings.json"), "{}");
+  writeFileSync(join(paths.cwd, ".pi", "pi-extensible-workflows", "roles", "reviewer.md"), "---\nmodel: openai/gpt:medium\n---\nReview the result");
+  const destination = join(paths.root, "bundle");
+  assert.equal(await runCli(["export", "cliEcho", "--bundle", "--approve", "--output", destination, "--role", "reviewer"], { cwd: paths.cwd, agentDir: paths.agentDir, stderr: () => {} }, () => {}), 0);
+  assert.deepEqual(readCliTestManifest(join(destination, "manifest.json")).requirements.roles, ["reviewer"]);
+});
 void test("portable bundle export writes a self-contained payload and external-runtime launcher", async () => {
   registerCliExtension();
   const paths = fixture();


### PR DESCRIPTION
## Summary

- preserve explicit `--approve` and `--no-approve` overrides when `export --bundle` delegates to bundle creation
- add regression coverage for trust-dependent project resources

## Verification

- `npm run build --workspace=packages/cli`
- focused `export bundle forwards explicit trust override` test passed
- `npm run lint --workspace=packages/cli`

The full CLI suite still encounters the existing unrelated TypeBox package-resolution fixture failure.
