### PR TITLE
fix(core): use current budget runtime for lifecycle persistence

### DIFF
--- a/packages/core/src/host-recovery.ts
+++ b/packages/core/src/host-recovery.ts
@@ -30,7 +30,7 @@ export type WorkflowRecoveryDependencies = {
   checkpointBridge: (runId: string, store: RunStore, metadata: WorkflowMetadata, foreground: boolean, ui?: { select?: (prompt: string, options: string[]) => Promise<string | undefined> }, headless?: boolean) => (raw: Readonly<Record<string, JsonValue>>, signal: AbortSignal) => Promise<boolean>;
   phaseBridge: (store: RunStore, metadata: WorkflowMetadata, lifecycle: RunLifecycle) => (phase: string) => Promise<void>;
   logBridge: (store: RunStore, lifecycle: RunLifecycle, workflowName: string) => (message: string) => Promise<void>;
-  lifecycleFor: (store: RunStore, state: RunState, budget: WorkflowBudgetRuntime, metadata: WorkflowMetadata) => RunLifecycle;
+  lifecycleFor: (store: RunStore, state: RunState, metadata: WorkflowMetadata) => RunLifecycle;
   createProviderErrorRecovery: (host: unknown, fallbackModels: ReadonlySet<string>, abort: () => void) => ((failure: AgentProviderFailure) => Promise<AgentProviderRecovery>) | undefined;
   cleanupTerminalRun: (runId: string) => Promise<void>;
   deliver: (content: string) => void;
@@ -295,7 +295,7 @@ export function createWorkflowRecovery(deps: WorkflowRecoveryDependencies) {
       await childStore.create({ id: childRunId, workflowName: loaded.snapshot.metadata.name, cwd, sessionId, state: "interrupted", parentRunId: loaded.run.id, retry, agents: [], agentSessions: [], ...(budget ? { budget } : {}), budgetVersion: loaded.run.budgetVersion ?? 1, ...childInitialBudget }, childSnapshot);
       const fallbackModel: ModelSpec = { provider: hostModel.provider, model: hostModel.id, thinking: pi.getThinkingLevel() };
       const model = modelSpec(loaded.snapshot.models[0] ?? "", fallbackModel);
-      const lifecycle = lifecycleFor(childStore, "interrupted", childBudget, loaded.snapshot.metadata);
+      const lifecycle = lifecycleFor(childStore, "interrupted", loaded.snapshot.metadata);
       const abortController = new AbortController();
       const providerErrorRecovery = createProviderErrorRecovery(context, availableModels, () => { abortController.abort(); });
       const providerPause = async () => { deliver(`Workflow ${loaded.snapshot.metadata.name} paused: provider limit.`); await lifecycle.providerPause(); };

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -557,10 +557,12 @@ export default function workflowExtension(pi: WorkflowExtensionAPI, home?: strin
       }
     } finally { await lifecycle.leave(); }
   };
-  const lifecycleFor = (store: RunStore, state: RunState, budget: WorkflowBudgetRuntime, metadata: WorkflowMetadata) => new RunLifecycle(state, async (next, previous, reason) => {
-    if (next !== "pausing") budget.transition(next);
+  const lifecycleFor = (store: RunStore, state: RunState, metadata: WorkflowMetadata) => new RunLifecycle(state, async (next, previous, reason) => {
+    const run = runs.get(store.runId);
+    if (!run) throw new WorkflowError("INTERNAL_ERROR", `Unknown production run: ${store.runId}`);
+    if (next !== "pausing") run.budget.transition(next);
     const persisted = await persistRunState(store, metadata, (current) => {
-      const nextRun = { ...current, state: next, ...budget.snapshot() };
+      const nextRun = { ...current, state: next, ...run.budget.snapshot() };
       if (next === "running" || next === "completed") { delete nextRun.error; delete nextRun.failedAt; }
       if (next === "running" && (previous === "paused" || previous === "interrupted" || previous === "budget_exhausted") && nextRun.delivery?.state === "delivered") nextRun.delivery = { ...nextRun.delivery, state: "pending" };
       return nextRun;
@@ -1058,7 +1060,7 @@ export default function workflowExtension(pi: WorkflowExtensionAPI, home?: strin
       const budget = validateBudget(loaded.run.budget ?? loaded.snapshot.budget);
       eventPublisher.seedBudget(runId, loaded.run.budgetEvents);
       const budgetRuntime = new WorkflowBudgetRuntime(budget, loaded.run.budgetVersion ?? 1, loaded.run.usage, loaded.run.budgetEvents, { active: loaded.run.state === "running" });
-      const lifecycle = lifecycleFor(store, loaded.run.state, budgetRuntime, loaded.snapshot.metadata);
+      const lifecycle = lifecycleFor(store, loaded.run.state, loaded.snapshot.metadata);
       const providerPause = async () => { deliver(pi, `Workflow ${loaded.snapshot.metadata.name} paused: provider limit.`); await lifecycle.providerPause(); };
       const roleDefinitions = loaded.snapshot.roles ?? {};
       const abortController = new AbortController();
@@ -1201,7 +1203,7 @@ export default function workflowExtension(pi: WorkflowExtensionAPI, home?: strin
         };
         deliveryController.foregroundDeliveries.set(toolCallId, delivery);
       }
-      const lifecycle = lifecycleFor(store, "running", budgetRuntime, checked.metadata);
+      const lifecycle = lifecycleFor(store, "running", checked.metadata);
       const backgroundLaunch = !params.foreground;
       const providerPause = async () => { if (!foregroundAttached) deliver(pi, `Workflow ${checked.metadata.name} paused: provider limit.`); await lifecycle.providerPause(); };
       const providerErrorRecovery = createProviderErrorRecovery(ctx, availableModels, () => { runController.abort(); });

--- a/packages/core/test/budget.test.ts
+++ b/packages/core/test/budget.test.ts
@@ -232,7 +232,7 @@ void test("completed final overruns complete, while later budgeted work reaches 
   assert.ok(sessionCount >= 2);
 });
 
-void test("workflow_resume persists exact proposals and approval or rejection controls exhausted runs", async () => {
+void test("workflow_resume preserves replacement budget accounting through terminal persistence", async () => {
   const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-budget-resume-"));
   const cwd = join(home, "project");
   const runId = "budget-run";
@@ -240,14 +240,14 @@ void test("workflow_resume persists exact proposals and approval or rejection co
   const usage = { tokens: 4, costUsd: 0, durationMs: 0, agentLaunches: 1 };
   const exhausted = { type: "hard_exhausted" as const, budgetVersion: 1, dimensions: ["tokens"] as const, usage, limits: budget, at: 0 };
   const store = new RunStore(cwd, "session", runId, home);
-  await store.create({ id: runId, workflowName: "resume-budget", cwd, sessionId: "session", state: "budget_exhausted", agents: [], agentSessions: [], budget, budgetVersion: 1, usage, budgetEvents: [exhausted] }, createLaunchSnapshot({ script: "return true;", args: null, metadata: { name: "resume-budget" }, launchMode: "foreground", settings: { concurrency: 1 }, budget, models: ["openai/gpt"], tools: [], agentTypes: [], roles: {}, schemas: [] }));
+  await store.create({ id: runId, workflowName: "resume-budget", cwd, sessionId: "session", state: "budget_exhausted", agents: [], agentSessions: [], budget, budgetVersion: 1, usage, budgetEvents: [exhausted] }, createLaunchSnapshot({ script: "return await agent('work');", args: null, metadata: { name: "resume-budget" }, launchMode: "foreground", settings: { concurrency: 1 }, budget, models: ["openai/gpt"], tools: [], agentTypes: [], roles: {}, schemas: [] }));
   const agentDir = join(home, "agent");
   mkdirSync(join(agentDir, "pi-extensible-workflows"), { recursive: true });
   const tools: Array<{ name: string; execute: (...args: unknown[]) => Promise<unknown> }> = [];
   const events: Array<{ channel: string; data: unknown }> = [];
   let start: ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
   let shutdown: (() => Promise<void>) | undefined;
-  workflowExtension(testExtensionApi({ registerTool(tool: (typeof tools)[number]) { tools.push(tool); }, registerCommand() {}, on(name: string, handler: unknown) { if (name === "session_start") start = handler as typeof start; if (name === "session_shutdown") shutdown = handler as typeof shutdown; }, sendMessage() {}, getThinkingLevel: () => "medium", getActiveTools: () => ["workflow", "workflow_respond"], events: { emit(channel: string, data: unknown) { events.push({ channel, data }); } } }), home, undefined, undefined, agentDir);
+  workflowExtension(testExtensionApi({ registerTool(tool: (typeof tools)[number]) { tools.push(tool); }, registerCommand() {}, on(name: string, handler: unknown) { if (name === "session_start") start = handler as typeof start; if (name === "session_shutdown") shutdown = handler as typeof shutdown; }, sendMessage() {}, getThinkingLevel: () => "medium", getActiveTools: () => ["workflow", "workflow_respond"], events: { emit(channel: string, data: unknown) { events.push({ channel, data }); } } }), home, undefined, testTransport(async () => budgetSession([{ content: [{ type: "text", text: "done" }], usage: budgetUsage(2, 0) }])), agentDir);
   let resolverCalls = 0;
   registerWorkflowExtension({ version: "1.0.0", headline: "Budget model policy", modelAliases: { "reviewer-model": { resolve(context) { resolverCalls += 1; assert.equal(context.projectTrusted, false); assert.ok(context.availableModels.has("new/model")); return "new/model"; } } } });
   const context = { cwd, model: { provider: "openai", id: "gpt" }, isProjectTrusted: () => false, modelRegistry: { getAll: () => [{ provider: "openai", id: "gpt" }, { provider: "new", id: "model" }], getAvailable: () => [{ provider: "openai", id: "gpt" }, { provider: "new", id: "model" }] }, sessionManager: { getSessionId: () => "session" } };
@@ -277,7 +277,7 @@ void test("workflow_resume persists exact proposals and approval or rejection co
   assert.equal(approvedDetails.state, "completed");
   assert.equal(approvedDetails.approved, true);
   assert.equal(approvedDetails.reason, "approved");
-  assert.equal(approvedDetails.value, true);
+  assert.equal(approvedDetails.value, "done");
   const approvedContent = JSON.parse((approved as { content: Array<{ text: string }> }).content[0]?.text ?? "null") as { state: string; approved: boolean; runId: string; value: { state: string; runId: string; resultPath: string; resultBytes: number; inlined: boolean } };
   assert.equal(approvedContent.state, "completed");
   assert.equal(approvedContent.approved, true);
@@ -291,6 +291,12 @@ void test("workflow_resume persists exact proposals and approval or rejection co
   assert.equal(loaded.run.state, "completed");
   assert.equal(loaded.run.budgetVersion, 2);
   assert.deepEqual(loaded.run.budget, { tokens: { soft: 2, hard: 10 } });
+  assert.ok(loaded.run.usage);
+  assert.equal(loaded.run.usage.tokens, 6);
+  assert.equal(loaded.run.usage.agentLaunches, 2);
+  assert.ok(loaded.run.budgetEvents);
+  assert.equal(loaded.run.budgetEvents.some((event) => event.budgetVersion === 1 && event.type === "soft_crossed"), false);
+  assert.ok(loaded.run.budgetEvents.some((event) => event.budgetVersion === 2 && event.type === "soft_crossed"));
   assert.deepEqual(loaded.snapshot.modelAliases, { "reviewer-model": "new/model" });
   assert.equal(resolverCalls, 1);
   assert.equal(events.filter(({ channel }) => channel === WORKFLOW_RUN_STARTED_EVENT).length, 0);


### PR DESCRIPTION
## Summary
- resolve the current run budget during lifecycle transitions
- prevent adjusted budget usage and events from being overwritten by the pre-adjustment runtime
- cover resumed agent accounting through terminal persistence

## Verification
- `npm run build --workspace=packages/core`
- `node --test --test-timeout=120000 --test-force-exit packages/core/dist/test/budget.test.js` (10/10)
- `npm run lint --workspace=packages/core`
