### PR TITLE
fix(core): stage Trajectory export assets

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.json && cp -R starter/roles dist/starter/roles && cp -R trajectory/src/assets dist/trajectory/src/assets && esbuild src/index.ts starter/index.ts subagents/index.ts trajectory/index.ts --bundle --format=esm --platform=node --packages=external --sourcemap --sources-content=false --outbase=. --outdir=dist",
+    "build": "rm -rf dist && tsc -p tsconfig.json && cp -R starter/roles dist/starter/roles && cp -R trajectory/src/assets dist/trajectory/src/assets && cp -R trajectory/src/assets dist/trajectory/assets && esbuild src/index.ts starter/index.ts subagents/index.ts trajectory/index.ts --bundle --format=esm --platform=node --packages=external --sourcemap --sources-content=false --outbase=. --outdir=dist",
     "lint": "eslint .",
     "test": "npm run test:layout && npm run build && npm run test:widget && npm run test:run && npm run test:herdr && npm run test:subagents",
     "test:layout": "node --test --test-timeout=10000 --test-force-exit test/workspace-layout.test.mjs",

--- a/packages/core/trajectory/test/trajectory-export.test.ts
+++ b/packages/core/trajectory/test/trajectory-export.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { exportTrajectoryRunHtml, shareTrajectoryRun } from "../src/export.js";
+import { exportTrajectoryRunHtml, shareTrajectoryRun } from "../index.js";
 import { RunStore } from "../../src/persistence.js";
 import { createLaunchSnapshot } from "../../src/utils.js";
 import type { PersistedRun } from "../../src/persistence.js";


### PR DESCRIPTION
Cause: the public `./trajectory` entry bundles `exportTrajectoryRunHtml` at `dist/trajectory/index.js`, but its `./assets` files were staged only under `dist/trajectory/src/assets` for the detached server.

Fix: stage the Trajectory assets at both the detached server path and the public entry path. Update the export regression to import the built public entry.

Verification:
- `npm run build --workspace=packages/core`
- `TEST_FILES='dist/trajectory/test/trajectory-export.test.js' npm run test:run --workspace=packages/core`
- `npm run lint --workspace=packages/core`