### PR TITLE
fix(cli): preserve aliased bundle extension imports

### DIFF
--- a/packages/cli/src/bundles.ts
+++ b/packages/cli/src/bundles.ts
@@ -436,7 +436,7 @@ function copyResources(root: string, resources: PortableWorkflowBundleResources 
 }
 
 function extensionPackageShim(paths: readonly string[]): string {
-  const bindings = new Map<string, string>();
+  const importedNames = new Set<string>();
   for (const path of paths) {
     if (!/\.(?:c|m)?js$/.test(path)) throw new Error(`Selected extension must be a JavaScript module file: ${path}`);
     const source = readFileSync(path, "utf8");
@@ -445,11 +445,11 @@ function extensionPackageShim(paths: readonly string[]): string {
         const pieces = part.trim().split(/\s+as\s+/);
         const imported = pieces[0]?.trim();
         const local = pieces[1]?.trim() ?? imported;
-        if (imported && local && /^[A-Za-z_$][\w$]*$/.test(local)) bindings.set(local, imported);
+        if (imported && local && /^[A-Za-z_$][\w$]*$/.test(local)) importedNames.add(imported);
       }
     }
   }
-  return [...bindings.entries()].map(([local, imported]) => `export const ${local} = globalThis.__pi_bundle_api.${imported};`).join("\n") + "\n";
+  return [...importedNames].map((name) => `export const ${name} = globalThis.__pi_bundle_api.${name};`).join("\n") + "\n";
 }
 
 export function writePortableWorkflowBundle(input: PortableWorkflowBundleInput): PortableWorkflowManifest {

--- a/packages/cli/src/bundles.ts
+++ b/packages/cli/src/bundles.ts
@@ -442,10 +442,8 @@ function extensionPackageShim(paths: readonly string[]): string {
     const source = readFileSync(path, "utf8");
     for (const match of source.matchAll(/import\s*\{([^}]+)\}\s*from\s*["']pi-extensible-workflows["']/g)) {
       for (const part of (match[1] ?? "").split(",")) {
-        const pieces = part.trim().split(/\s+as\s+/);
-        const imported = pieces[0]?.trim();
-        const local = pieces[1]?.trim() ?? imported;
-        if (imported && local && /^[A-Za-z_$][\w$]*$/.test(local)) importedNames.add(imported);
+        const imported = part.trim().split(/\s+as\s+/, 1)[0]?.trim();
+        if (imported && /^[A-Za-z_$][\w$]*$/.test(imported)) importedNames.add(imported);
       }
     }
   }

--- a/packages/cli/test/bundles.test.ts
+++ b/packages/cli/test/bundles.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -41,6 +41,29 @@ void test("bundle loads extensions with aliased workflow API imports", async () 
   } finally {
     if (previousApi === undefined) delete (globalThis as typeof globalThis & { __pi_bundle_api?: unknown }).__pi_bundle_api;
     else (globalThis as typeof globalThis & { __pi_bundle_api: unknown }).__pi_bundle_api = previousApi;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+void test("bundle shim omits invalid emitted names", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-bundle-"));
+  try {
+    const extension = join(root, "invalid-extension.mjs");
+    writeFileSync(extension, 'import { "invalid-name" as validName } from "pi-extensible-workflows";\n');
+    const destination = join(root, "bundle");
+    writePortableWorkflowBundle({
+      destination,
+      command: "invalid-name-bundle",
+      workflow: { name: "bundle-test", version: "1.0.0", headline: "Bundle test", description: "Bundle test", input: { type: "object" }, output: { type: "string" } },
+      functionSource: "(input) => input",
+      piVersion: "unknown",
+      engineVersion: "unknown",
+      resources: { extensions: [extension] },
+    });
+
+    const shim = readFileSync(join(destination, "payload", "node_modules", "pi-extensible-workflows", "index.mjs"), "utf8");
+    assert.equal(shim, "\n");
+  } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/packages/cli/test/bundles.test.ts
+++ b/packages/cli/test/bundles.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+import { writePortableWorkflowBundle } from "../src/bundles.js";
+
+type BundlePayload = { register: (registerWorkflowExtension: (extension: unknown) => void) => Promise<void> };
+
+void test("bundle loads extensions with aliased workflow API imports", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-bundle-"));
+  const previousApi = (globalThis as typeof globalThis & { __pi_bundle_api?: unknown }).__pi_bundle_api;
+  try {
+    const extension = join(root, "aliased-extension.mjs");
+    writeFileSync(extension, [
+      'import { registerWorkflowExtension as register } from "pi-extensible-workflows";',
+      "export default function extension() {",
+      '  register({ version: "1.0.0", headline: "Aliased extension", functions: {} });',
+      "}",
+      "",
+    ].join("\n"));
+    const destination = join(root, "bundle");
+    writePortableWorkflowBundle({
+      destination,
+      command: "aliased-bundle",
+      workflow: { name: "bundle-test", version: "1.0.0", headline: "Bundle test", description: "Bundle test", input: { type: "object" }, output: { type: "string" } },
+      functionSource: "(input) => input",
+      piVersion: "unknown",
+      engineVersion: "unknown",
+      resources: { extensions: [extension] },
+    });
+
+    const registered: unknown[] = [];
+    (globalThis as typeof globalThis & { __pi_bundle_api: unknown }).__pi_bundle_api = { registerWorkflowExtension: (value: unknown) => registered.push(value) };
+    const payload = await import(pathToFileURL(join(destination, "payload", "workflow.mjs")).href) as BundlePayload;
+    await payload.register((value: unknown) => registered.push(value));
+
+    assert.equal(registered.length, 2);
+    assert.deepEqual(registered[0], { version: "1.0.0", headline: "Aliased extension", functions: {} });
+  } finally {
+    if (previousApi === undefined) delete (globalThis as typeof globalThis & { __pi_bundle_api?: unknown }).__pi_bundle_api;
+    else (globalThis as typeof globalThis & { __pi_bundle_api: unknown }).__pi_bundle_api = previousApi;
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- export original named imports from the copied bundle extension shim
- add an execution/linking regression for aliased imports

## Verification
- `npm run build --workspace=packages/cli`
- `TEST_FILES='dist/test/bundles.test.js' npm run test:run --workspace=packages/cli`
- `npm run lint --workspace=packages/cli`

Unrelated known fixture failures: none encountered.