### PR TITLE
test(core): forward real delivery options

### DIFF
--- a/packages/core/test/checkpoints-delivery.test.ts
+++ b/packages/core/test/checkpoints-delivery.test.ts
@@ -343,14 +343,14 @@ void test("a checkpoint answer persisted before resolver registration cannot han
 void test("foreground and background completion delivery share bounded results", async () => {
   const home = mkdtempSync(join(tmpdir(), "pi-extensible-workflows-delivery-"));
   const tools: Array<{ name: string; execute: (...args: unknown[]) => Promise<{ content: Array<{ text: string }>; details?: { runId: string; value?: unknown } }> }> = [];
-  const messages: Array<{ message: { content: string }; options: { deliverAs: string; triggerTurn: boolean } }> = [];
+  const messages: Array<{ message: { content: string }; options: { deliverAs?: string; triggerTurn?: boolean } | undefined }> = [];
   let markDelivered!: () => void;
   const delivered = new Promise<void>((resolve) => { markDelivered = resolve; });
   let toolResultHandler: ((event: { toolName: string; toolCallId: string; isError: boolean }) => Promise<unknown>) | undefined;
   const pi = {
     registerTool(tool: (typeof tools)[number]) { tools.push(tool); }, registerCommand() {}, on(name: string, handler: unknown) { if (name === "tool_result") toolResultHandler = handler as typeof toolResultHandler; },
     getThinkingLevel: () => "medium" as const, getActiveTools: () => ["workflow"],
-    sendMessage(message: { content: string }, options: { deliverAs: string; triggerTurn: boolean }) { messages.push({ message, options }); markDelivered(); }
+    sendMessage(message: { content: string }, options?: { deliverAs?: string; triggerTurn?: boolean }) { messages.push({ message, options }); markDelivered(); }
   };
   workflowExtension(testExtensionApi(pi), home);
   const execute = tools.find(({ name }) => name === "workflow")?.execute;

--- a/packages/core/test/support.ts
+++ b/packages/core/test/support.ts
@@ -44,7 +44,7 @@ type TestTool = {
   promptSnippet?: string;
 };
 type TestWorkflowMessage = { customType: string; content: string; display: boolean };
-type TestWorkflowMessageOptions = { deliverAs: "followUp"; triggerTurn: true };
+type TestWorkflowMessageOptions = NonNullable<Parameters<ExtensionAPI["sendMessage"]>[1]>;
 type TestWorkflowLogEntry = { workflowName: string; message: string };
 type TestExtensionApiOptions = {
   registerTool?(tool: TestTool): void;
@@ -53,7 +53,7 @@ type TestExtensionApiOptions = {
   getThinkingLevel?: ExtensionAPI["getThinkingLevel"];
   getActiveTools?: ExtensionAPI["getActiveTools"];
   appendEntry?: (type: string, data: TestWorkflowLogEntry) => void;
-  sendMessage?: (message: TestWorkflowMessage, options: TestWorkflowMessageOptions) => void;
+  sendMessage?: (message: TestWorkflowMessage, options?: TestWorkflowMessageOptions) => void;
   registerEntryRenderer?(type: string, renderer: unknown): void;
   registerShortcut?: ExtensionAPI["registerShortcut"];
   events?: {
@@ -75,12 +75,11 @@ export function testExtensionApi(options: TestExtensionApiOptions = {}): Workflo
     on: options.on ?? (() => {}),
     registerCommand: options.registerCommand ?? (() => {}),
     registerTool(tool) { options.registerTool?.(tool); },
-    sendMessage(message) {
+    sendMessage(message, deliveryOptions) {
       if (typeof message.content !== "string") return;
       const customType = typeof message.customType === "string" ? message.customType : "workflow";
       const display = message.display;
-      const optionsForTest: TestWorkflowMessageOptions = { deliverAs: "followUp", triggerTurn: true };
-      options.sendMessage?.({ customType, content: message.content, display }, optionsForTest);
+      options.sendMessage?.({ customType, content: message.content, display }, deliveryOptions);
     },
   };
   const registerEntryRenderer: ExtensionAPI["registerEntryRenderer"] = (type, renderer) => { options.registerEntryRenderer?.(type, renderer); };


### PR DESCRIPTION
## Summary
- forward the actual optional Pi sendMessage delivery options through the core test helper
- keep the completion delivery regression assertion checking production options

## Verification
- npm run build --workspace=packages/core
- node --test --test-timeout=120000 --test-force-exit packages/core/dist/test/checkpoints-delivery.test.js
- npm run lint --workspace=packages/core